### PR TITLE
Implemented programatic switch having the 2.1 as base branch

### DIFF
--- a/1bash
+++ b/1bash
@@ -229,7 +229,7 @@ nvOC_1bash_ver="v0019-2.1.0019"   # Do not edit this
 #                                                      #
 ########################################################
 
-COIN="SALFTER_PROGRAMATIC_SWITCHING"
+COIN="ZEC"
 
 AUTO_START_MINER="YES"      # YES or NO # Set this to NO when troubleshooting, this will prevent the watchdog restarting the rig
 
@@ -924,6 +924,7 @@ DUAL_ADDITIONAL_ARGUMENTS=""                #add "-allcoins 1" if you mine Ether
 #                                                      #
 ########################################################
 
+# Change this url to one you use for your own
 PROGRAMATIC_SWITCH_CONFIG_JSON_URL="https://pastebin.com/dl/eLU4B8rK"
 
 CURRENCY=USD

--- a/1bash
+++ b/1bash
@@ -229,7 +229,7 @@ nvOC_1bash_ver="v0019-2.1.0019"   # Do not edit this
 #                                                      #
 ########################################################
 
-COIN="ZEC"
+COIN="SALFTER_PROGRAMATIC_SWITCHING"
 
 AUTO_START_MINER="YES"      # YES or NO # Set this to NO when troubleshooting, this will prevent the watchdog restarting the rig
 
@@ -919,10 +919,12 @@ DUAL_ADDITIONAL_ARGUMENTS=""                #add "-allcoins 1" if you mine Ether
 ########################################################
 #                                                      #
 # SALFTER_NICEHASH_PROFIT_SWITCHING &                  #
-# SALFTER_MPH_PROFIT_SWITCHING Settings                #
+# SALFTER_MPH_PROFIT_SWITCHING &                       #
+# SALFTER_PROGRAMATIC_SWITCHING Settings               #
 #                                                      #
 ########################################################
 
+PROGRAMATIC_SWITCH_CONFIG_JSON_URL="https://pastebin.com/dl/eLU4B8rK"
 
 CURRENCY=USD
 

--- a/1bash
+++ b/1bash
@@ -207,6 +207,7 @@ nvOC_1bash_ver="v0019-2.1.0019"   # Do not edit this
 #TYPE - Profit Switchers
 ######### SALFTER_NICEHASH_PROFIT_SWITCHING
 ######### SALFTER_MPH_PROFIT_SWITCHING
+######### SALFTER_PROGRAMATIC_SWITCHING       # - change what coin/algo you mine through an external JSON configuration file 
 
 ### New Coins: LUX, SUMO, DSR, ELLA, XVG, GBX, CRC, BTCP
 

--- a/3main
+++ b/3main
@@ -924,7 +924,7 @@ then
     },
     "Cryptonight-Heavy":
     {
-      "bin": "/home/m1/xmr/xmrig-nvidia-miner/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
+      "bin": "/home/m1/xmr/xmrig-nvidia/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
       "power_limit": $Cryptonight_POWERLIMIT_WATTS, "gpu_oc": $__Cryptonight_CORE_OVERCLOCK, "mem_oc": $Cryptonight_MEMORY_OVERCLOCK, "fan": 0
     },
     "Equihash":

--- a/3main
+++ b/3main
@@ -67,10 +67,11 @@ NVD=nvidia-settings
 
 SALFTER="NO"
 
-if [[ $COIN == "SALFTER_NICEHASH_PROFIT_SWITCHING" || $COIN == "SALFTER_MPH_PROFIT_SWITCHING" ]]
+if [[ $COIN == "SALFTER_NICEHASH_PROFIT_SWITCHING" || $COIN == "SALFTER_MPH_PROFIT_SWITCHING" || $COIN == "SALFTER_PROGRAMATIC_SWITCHING" ]]
 then
   SALFTER="YES"
 fi
+
 
 if [[ $CLEAR_LOGS_ON_BOOT == YES ]]
 then
@@ -827,6 +828,218 @@ then
   echo "    "
 fi
 
+#################################
+# SALFTER_PROGRAMATIC_SWITCHING #
+#################################
+
+if [[ $COIN == "SALFTER_PROGRAMATIC_SWITCHING" && $AUTO_START_MINER == "YES" ]]
+then
+  cd /home/m1
+  if [[ "$INDIVIDUAL_CLOCKS" == YES ]]
+  then
+    gpu_clks_daggerhashimoto="[$__CORE_OVERCLOCK_0,$__CORE_OVERCLOCK_1,$__CORE_OVERCLOCK_2,$__CORE_OVERCLOCK_3,$__CORE_OVERCLOCK_4,$__CORE_OVERCLOCK_5,$__CORE_OVERCLOCK_6,$__CORE_OVERCLOCK_7,$__CORE_OVERCLOCK_8,$__CORE_OVERCLOCK_9,$__CORE_OVERCLOCK_10,$__CORE_OVERCLOCK_11,$__CORE_OVERCLOCK_12,$__CORE_OVERCLOCK_13,$__CORE_OVERCLOCK_14,$__CORE_OVERCLOCK_15,$__CORE_OVERCLOCK_16,$__CORE_OVERCLOCK_17,$__CORE_OVERCLOCK_18]"
+
+    mem_clks_daggerhashimoto="[$MEMORY_OVERCLOCK_0,$MEMORY_OVERCLOCK_1,$MEMORY_OVERCLOCK_2,$MEMORY_OVERCLOCK_3,$MEMORY_OVERCLOCK_4,$MEMORY_OVERCLOCK_5,$MEMORY_OVERCLOCK_6,$MEMORY_OVERCLOCK_7,$MEMORY_OVERCLOCK_8,$MEMORY_OVERCLOCK_9,$MEMORY_OVERCLOCK_10,$MEMORY_OVERCLOCK_11,$MEMORY_OVERCLOCK_12,$MEMORY_OVERCLOCK_13,$MEMORY_OVERCLOCK_14,$MEMORY_OVERCLOCK_15,$MEMORY_OVERCLOCK_16,$MEMORY_OVERCLOCK_17,$MEMORY_OVERCLOCK_18]"
+
+    gpu_clks_equihash=$gpu_clks_daggerhashimoto
+    mem_clks_equihash=$mem_clks_daggerhashimoto
+    gpu_clks_neoscrypt=$gpu_clks_daggerhashimoto
+    mem_clks_neoscrypt=$mem_clks_daggerhashimoto
+    gpu_clks_lyra2rev2=$gpu_clks_daggerhashimoto
+    mem_clks_lyra2rev2=$mem_clks_daggerhashimoto
+    gpu_clks_lbry=$gpu_clks_daggerhashimoto
+    mem_clks_lbry=$mem_clks_daggerhashimoto
+    __Blake_Vanilla_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Blake_Vanilla_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Cryptonight_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Cryptonight_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Groestl_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Groestl_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Keccak_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Keccak_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Myriad_Groestl_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Myriad_Groestl_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Qubit_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Qubit_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Scrypt_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Scrypt_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Sia_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Sia_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __Skein_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    Skein_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+    __X11_CORE_OVERCLOCK=$gpu_clks_daggerhashimoto
+    X11_MEMORY_OVERCLOCK=$mem_clks_daggerhashimoto
+  else
+    gpu_clks_daggerhashimoto="$__daggerhashimoto_CORE_OVERCLOCK"
+    mem_clks_daggerhashimoto="$daggerhashimoto_MEMORY_OVERCLOCK"
+    gpu_clks_equihash="$__equihash_CORE_OVERCLOCK"
+    mem_clks_equihash="$equihash_MEMORY_OVERCLOCK"
+    gpu_clks_neoscrypt="$__neoscrypt_CORE_OVERCLOCK"
+    mem_clks_neoscrypt="$neoscrypt_MEMORY_OVERCLOCK"
+    gpu_clks_lyra2rev2="$__lyra2rev2_CORE_OVERCLOCK"
+    mem_clks_lyra2rev2="$lyra2rev2_MEMORY_OVERCLOCK"
+    gpu_clks_lbry="$__lbry_CORE_OVERCLOCK"
+    mem_clks_lbry="$lbry_MEMORY_OVERCLOCK"
+  fi
+
+  if [[ "$INDIVIDUAL_POWERLIMIT" == YES ]]
+  then
+    pwr_lim_daggerhashimoto="[$INDIVIDUAL_POWERLIMIT_0,$INDIVIDUAL_POWERLIMIT_1,$INDIVIDUAL_POWERLIMIT_2,$INDIVIDUAL_POWERLIMIT_3,$INDIVIDUAL_POWERLIMIT_4,$INDIVIDUAL_POWERLIMIT_5,$INDIVIDUAL_POWERLIMIT_6,$INDIVIDUAL_POWERLIMIT_7,$INDIVIDUAL_POWERLIMIT_8,$INDIVIDUAL_POWERLIMIT_9,$INDIVIDUAL_POWERLIMIT_10,$INDIVIDUAL_POWERLIMIT_11,$INDIVIDUAL_POWERLIMIT_12,$INDIVIDUAL_POWERLIMIT_13,$INDIVIDUAL_POWERLIMIT_14,$INDIVIDUAL_POWERLIMIT_15,$INDIVIDUAL_POWERLIMIT_16,$INDIVIDUAL_POWERLIMIT_17,$INDIVIDUAL_POWERLIMIT_18]"
+    pwr_lim_equihash=$pwr_lim_daggerhashimoto
+    pwr_lim_neoscrypt=$pwr_lim_daggerhashimoto
+    pwr_lim_lyra2rev2=$pwr_lim_daggerhashimoto
+    pwr_lim_lbry=$pwr_lim_daggerhashimoto
+    Blake_Vanilla_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Cryptonight_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Groestl_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Keccak_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Myriad_Groestl_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Qubit_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Scrypt_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Sia_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    Skein_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+    X11_POWERLIMIT_WATTS=$pwr_lim_daggerhashimoto
+  else
+    pwr_lim_daggerhashimoto=$daggerhashimoto_POWERLIMIT_WATTS
+    pwr_lim_equihash=$equihash_POWERLIMIT_WATTS
+    pwr_lim_neoscrypt=$neoscrypt_POWERLIMIT_WATTS
+    pwr_lim_lyra2rev2=$lyra2rev2_POWERLIMIT_WATTS
+    pwr_lim_lbry=$lbry_POWERLIMIT_WATTS
+  fi
+
+  cat <<EOF >/home/m1/programatic_conf.json
+{
+  "card_type": "nvidia",
+  "miners":
+  {
+    "Blake-Vanilla":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a vanilla -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Blake_Vanilla_POWERLIMIT_WATTS, "gpu_oc": $__Blake_Vanilla_CORE_OVERCLOCK, "mem_oc": $Blake_Vanilla_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Cryptonight":
+    {
+      "bin": "/home/m1/KTccminer-cryptonight/ccminer -o stratum+tcp://{HOST}:{PORT} -u {NAME} -p x",
+      "power_limit": $Cryptonight_POWERLIMIT_WATTS, "gpu_oc": $__Cryptonight_CORE_OVERCLOCK, "mem_oc": $Cryptonight_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Cryptonight-Heavy":
+    {
+      "bin": "/home/m1/xmr/xmrig-nvidia-miner/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
+      "power_limit": $Cryptonight_POWERLIMIT_WATTS, "gpu_oc": $__Cryptonight_CORE_OVERCLOCK, "mem_oc": $Cryptonight_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Equihash":
+    {
+      "bin": "/home/m1/zec/zm/latest/zm_miner --server {HOST} --port {PORT} --user {NAME}.{MINER} --pass x --telemetry=0.0.0.0:2222 --time --color",
+      "power_limit": $pwr_lim_equihash, "gpu_oc": $gpu_clks_equihash, "mem_oc": $mem_clks_equihash, "fan": 0
+    },
+    "Ethash":
+    {
+      "bin": "/home/m1/eth/ethminer_12dev2/ethminer -S {HOST}:{PORT} -O {NAME}.{MINER}:x -U",
+      "power_limit": $pwr_lim_daggerhashimoto, "gpu_oc": $gpu_clks_daggerhashimoto, "mem_oc": $mem_clks_daggerhashimoto, "fan": 0
+    },
+    "Groestl":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a groestl -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Groestl_POWERLIMIT_WATTS, "gpu_oc": $__Groestl_CORE_OVERCLOCK, "mem_oc": $Groestl_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Keccak":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a keccak -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Keccak_POWERLIMIT_WATTS, "gpu_oc": $__Keccak_CORE_OVERCLOCK, "mem_oc": $Keccak_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Lyra2RE2":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a lyra2v2 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $pwr_lim_lyra2rev2, "gpu_oc": $gpu_clks_lyra2rev2, "mem_oc": $mem_clks_lyra2rev2, "fan": 0
+    },
+    "Myriad-Groestl":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a myr-gr -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Myriad_Groestl_POWERLIMIT_WATTS, "gpu_oc": $__Myriad_Groestl_CORE_OVERCLOCK, "mem_oc": $Myriad_Groestl_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "NeoScrypt":
+    {
+      "bin": "/home/m1/KTccminer/ccminer -a neoscrypt -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $pwr_lim_neoscrypt, "gpu_oc": $gpu_clks_neoscrypt, "mem_oc": $mem_clks_neoscrypt, "fan": 0
+    },
+    "Qubit":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a qubit -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Qubit_POWERLIMIT_WATTS, "gpu_oc": $__Qubit_CORE_OVERCLOCK, "mem_oc": $Qubit_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Scrypt":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a scrypt -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Scrypt_POWERLIMIT_WATTS, "gpu_oc": $__Scrypt_CORE_OVERCLOCK, "mem_oc": $Scrypt_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Sia":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a sia -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Sia_POWERLIMIT_WATTS, "gpu_oc": $__Sia_CORE_OVERCLOCK, "mem_oc": $Sia_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "Skein":
+    {
+      "bin": "/home/m1/ASccminer/ccminer -a skein -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $Skein_POWERLIMIT_WATTS, "gpu_oc": $__Skein_CORE_OVERCLOCK, "mem_oc": $Skein_MEMORY_OVERCLOCK, "fan": 0
+    },
+    "X11":
+    {
+      "bin": "/home/m1/TPccminer/ccminer -a x11 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": $X11_POWERLIMIT_WATTS, "gpu_oc": $__X11_CORE_OVERCLOCK, "mem_oc": $X11_MEMORY_OVERCLOCK, "fan": 0
+    }
+  }
+}
+EOF
+
+  echo "LAUNCHING:  SALFTER_PROGRAMATIC_SWITCHING "
+  echo ""
+
+  python2.7 '/home/m1/programatic_switch' /home/m1/programatic_conf.json
+
+  if [[ $LOCALorREMOTE == LOCAL ]]
+  then
+    guake -n 1 -r SALFTER_PROGRAMATIC_SWITCHING -e "screen -r miner"
+  fi
+
+  while true
+  do
+    echo ""
+    cat current-profit
+    echo ""
+    if [[ $LOCALorREMOTE == LOCAL ]]
+    then
+      guake -r SALFTER_PROGRAMATIC_SWITCHING -e "screen -r miner"
+      echo ""
+      echo "mining process in Guake Tab"
+      echo ""
+      sleep "$PROFIT_CHECK_TIMEOUT"
+      python2.7 '/home/m1/programatic_switch' /home/m1/programatic_conf.json
+    fi
+    if [[ $LOCALorREMOTE == REMOTE ]]
+    then
+      echo "ENTER:"
+      echo ""
+      echo "screen -r miner"
+      echo ""
+      echo "in a terminal to view mining process"
+      sleep "$PROFIT_CHECK_TIMEOUT"
+      python2.7 '/home/m1/programatic_switch' /home/m1/programatic_conf.json
+    fi
+  done
+elif [[ $COIN == "SALFTER_PROGRAMATIC_SWITCHING" && $AUTO_START_MINER == "NO" ]]
+then
+  echo "    "
+  echo "    "
+  echo "Auto Start Miner is set to NO"
+  echo "    "
+  echo "Miner is not starting"
+  echo "    "
+  echo "    "
+fi
+
+#####################################
+# END SALFTER_PROGRAMATIC_SWITCHING #
+#####################################
 
 if [[ $SALFTER == NO ]]
 then

--- a/3main
+++ b/3main
@@ -910,6 +910,7 @@ then
   cat <<EOF >/home/m1/programatic_conf.json
 {
   "card_type": "nvidia",
+  "config_json_url": "$PROGRAMATIC_SWITCH_CONFIG_JSON_URL",
   "miners":
   {
     "Blake-Vanilla":

--- a/minerinfo
+++ b/minerinfo
@@ -119,6 +119,13 @@ then
   AUTO_SWITCH="Salfter Nicehash Auto Switch"
 
 
+elif [ $COIN == "SALFTER_PROGRAMATIC_SWITCHING" ]
+then
+  CURRENT_COIN=$(head -n 1 /home/m1/current-profit)
+  MINING_HISTORY=$(tail -n 5 /home/m1/algo-log |  awk '{print $0,"<br>"}')
+  AUTO_SWITCH=("Salfter Programatic Switch")
+
+
 elif [ $WTM_AUTO_SWITCH == "YES" ]
 then
   CURRENT_COIN=$COIN

--- a/programatic_conf.json
+++ b/programatic_conf.json
@@ -14,7 +14,7 @@
     },
     "Cryptonight-Heavy":
     {
-      "bin": "/home/m1/xmr/xmrig-nvidia-miner/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
+      "bin": "/home/m1/xmr/xmrig-nvidia/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
     },
     "Equihash":

--- a/programatic_conf.json
+++ b/programatic_conf.json
@@ -1,0 +1,81 @@
+{
+  "card_type": "nvidia",
+  "miners":
+  {
+    "Blake-Vanilla":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a vanilla -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Cryptonight":
+    {
+      "bin": "/home/m1/KTccminer-cryptonight/ccminer -o stratum+tcp://{HOST}:{PORT} -u {NAME} -p x",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Cryptonight-Heavy":
+    {
+      "bin": "/home/m1/xmr/xmrig-nvidia-miner/xmrig-nvidia -a cryptonight-heavy -o {HOST}:{PORT} -u {NAME} -p x -k",
+     "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Equihash":
+    {
+      "bin": "/home/m1/zec/zm/latest/zm_miner --server {HOST} --port {PORT} --user {NAME}.{MINER} --pass x --telemetry=0.0.0.0:2222 --time --color",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Ethash":
+    {
+      "bin": "/home/m1/eth/ethminer_12dev2/ethminer -S {HOST}:{PORT} -O {NAME}.{MINER}:x -U",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Groestl":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a groestl -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Keccak":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a keccak -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Lyra2RE2":
+    {
+      "bin": "/home/m1/ASccminer/ccminer -a lyra2v2 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY} -i 21",
+      "power_limit": 125, "gpu_oc": 110, "mem_oc": 300, "fan": 0
+    },
+    "Myriad-Groestl":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a myr-gr -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "NeoScrypt":
+    {
+      "bin": "/home/m1/KTccminer/ccminer -a neoscrypt -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Qubit":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a qubit -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Scrypt":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a scrypt -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Sia":
+    {
+      "bin": "/home/m1/SPccminer/ccminer -a sia -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "Skein":
+    {
+      "bin": "/home/m1/ASccminer/ccminer -a skein -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    },
+    "X11":
+    {
+      "bin": "/home/m1/TPccminer/ccminer -a x11 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
+      "power_limit": 120, "gpu_oc": 100, "mem_oc": 100, "fan": 0
+    }
+  }
+}

--- a/programatic_switch
+++ b/programatic_switch
@@ -56,9 +56,6 @@ if (current==0):
   algo_log.write(str(datetime.datetime.now())+": "+coin+"\n")
   algo_log.close()
 
-
-  #subprocess.call(["/home/prospector/telegram"])
-  #time.sleep(3)
   # kill existing miners
   subprocess.call(["pkill", "-f","miner"])
   time.sleep(3)

--- a/programatic_switch
+++ b/programatic_switch
@@ -1,0 +1,102 @@
+#!/usr/bin/env python2.7
+
+import pprint
+import json
+import urllib2
+import sys
+import datetime
+import time
+import subprocess
+import os
+
+# load config
+
+cfg=json.loads(open(sys.argv[1]).read())
+
+card_type=cfg["card_type"]
+miners=cfg["miners"]
+miner_name=os.uname()[1]
+hostname=os.uname()[1]
+
+os.environ["DISPLAY"]=":0"
+
+# grab something from a website
+
+def fetch(url):
+  r=urllib2.Request(url)
+  r.add_header("User-Agent", "Lynx/2.8.8dev.3 libwww-FM/2.14 SSL-MM/1.4.1")
+  r.add_header("Pragma", "no-cache")
+  return urllib2.build_opener().open(r).read()
+
+# main
+
+data=json.loads(fetch(os.environ["PROGRAMATIC_SWITCH_CONFIG_JSON_URL"]))
+
+current_miner=data[miner_name]["current_miner"]
+
+miner=miners[current_miner["algo"]]
+coin=miner["bin"].format(HOST=current_miner["host"], PORT=str(current_miner["port"]), NAME=current_miner["user_name"], MINER=miner_name, COIN_CURRENCY=current_miner["coin_currency"])
+
+
+try:
+  subprocess.check_output(["pgrep", "-f", "^"+coin.replace("+", "\\+").replace("t:1","t 1").replace("0:2","0 2")])
+  current=1
+  print("no change")
+except:
+  current=0
+  print("change needed")
+  
+if (current==0):
+  # log current coin
+  log=open("current-profit", "w")
+  log.write(current_miner["algo"] + " - " + current_miner["coin_currency"] + " @ "+ current_miner["host"] + "\n")
+  log.close() 
+  # log a change
+  algo_log=open("algo-log", "a")
+  algo_log.write(str(datetime.datetime.now())+": "+coin+"\n")
+  algo_log.close()
+
+
+  #subprocess.call(["/home/prospector/telegram"])
+  #time.sleep(3)
+  # kill existing miners
+  subprocess.call(["pkill", "-f","miner"])
+  time.sleep(3)
+  
+  if card_type=="nvidia": # update card settings
+    cards=int(subprocess.check_output("nvidia-smi --query-gpu=count --format=csv,noheader,nounits".split(" ")).split("\n")[-2])
+    for i in range(0, cards):
+      # power limit
+      if type(miner["power_limit"]) is int:
+        subprocess.call(("sudo nvidia-smi -i "+str(i)+" -pl "+str(miner["power_limit"])).split(" "))
+      else:
+        subprocess.call(("sudo nvidia-smi -i "+str(i)+" -pl "+str(miner["power_limit"][i])).split(" "))
+      # core overclock
+      if type(miner["gpu_oc"]) is int:
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUGraphicsClockOffset[2]="+str(miner["gpu_oc"])).split(" "))
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUGraphicsClockOffset[3]="+str(miner["gpu_oc"])).split(" "))
+      else:
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUGraphicsClockOffset[2]="+str(miner["gpu_oc"][i])).split(" "))
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUGraphicsClockOffset[3]="+str(miner["gpu_oc"][i])).split(" "))
+      # memory overclock
+      if type(miner["mem_oc"]) is int:
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUMemoryTransferRateOffset[2]="+str(miner["mem_oc"])).split(" "))
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUMemoryTransferRateOffset[3]="+str(miner["mem_oc"])).split(" "))
+      else:
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUMemoryTransferRateOffset[2]="+str(miner["mem_oc"][i])).split(" "))
+        subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUMemoryTransferRateOffset[3]="+str(miner["mem_oc"][i])).split(" "))
+      # fan speed
+      #if type(miner["fan"]) is int:
+      #  if (miner["fan"]==0):
+      #    subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUFanControlState=0").split(" "))
+       # else:
+       #   subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUFanControlState=1").split(" "))
+        #  subprocess.call(("nvidia-settings -a [fan:"+str(i)+"]/GPUTargetFanSpeed="+str(miner["fan"])).split(" "))
+      #else:
+      #  if (miner["fan"][i]==0):
+       #   subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUFanControlState=0").split(" "))
+       # else:
+       #   subprocess.call(("nvidia-settings -a [gpu:"+str(i)+"]/GPUFanControlState=1").split(" "))
+        #  subprocess.call(("nvidia-settings -a [fan:"+str(i)+"]/GPUTargetFanSpeed="+str(miner["fan"][i])).split(" "))
+  # launch new miner
+  subprocess.call(("screen -dmS miner "+coin).split(" "))

--- a/programatic_switch
+++ b/programatic_switch
@@ -30,7 +30,7 @@ def fetch(url):
 
 # main
 
-data=json.loads(fetch(os.environ["PROGRAMATIC_SWITCH_CONFIG_JSON_URL"]))
+data=json.loads(fetch(cfg["config_json_url"]))
 
 current_miner=data[miner_name]["current_miner"]
 

--- a/telegram
+++ b/telegram
@@ -94,6 +94,13 @@ then
     CURRENT_COIN=$(head -n 1 /home/m1/current-profit)
     MINING_HISTORY=$(tail -n 5 /home/m1/algo_log |  awk '{print $0}')
     AUTO_SWITCH=("Salfter Nicehash Auto Switch")
+    
+    
+  elif [ $COIN == "SALFTER_PROGRAMATIC_SWITCHING" ]
+  then
+    CURRENT_COIN=$(head -n 1 /home/m1/current-profit)
+    MINING_HISTORY=$(tail -n 5 /home/m1/algo-log |  awk '{print $0,"<br>"}')
+    AUTO_SWITCH=("Salfter Programatic Switch")
 
 
   elif [ $WTM_AUTO_SWITCH == "YES" ]
@@ -1150,7 +1157,8 @@ then
       # Mining coin
       if [[ "$SEND_MINING_COIN" == "YES" ]]; then
 
-        if [[ "$COIN" == "SALFTER_NICEHASH_PROFIT_SWITCHING" || "$COIN" == "SALFTER_MPH_PROFIT_SWITCHING" ]]; then
+        if [[ "$COIN" == "SALFTER_NICEHASH_PROFIT_SWITCHING" || "$COIN" == "SALFTER_MPH_PROFIT_SWITCHING" || "$COIN" == "SALFTER_PROGRAMATIC_SWITCHING" ]]; then
+
           CURRENT_COIN=$(head -n 1 /home/m1/current-profit)
         else
           CURRENT_COIN=$COIN


### PR DESCRIPTION
Based on @salfter’s switchers i’ve implemented a programatic switcher, where the input would be a over-the-internet-accessible-json-file (could be hosted in google drive, pastebin, etc) having the following format:

```
{
  "RIG_HOSTNAME1": {
      "current_miner": {
          "algo":"Cryptonight",
          "coin_currency":"COIN_SYMBOL",
	      "host":"POOL_HOSTNAME",
          "port":POOL_PORT,
          "user_name":"CRYPTONIGHT_BASED_COIN_WALLET_ADDRESS"
      }
  },
  "RIG_HOSTNAME2": {
      "current_miner": {
          "algo":"Cryptonight-Heavy",
          "coin_currency":"COIN_SYMBOL",
	      "host":"POOL_HOSTNAME",
          "port":POOL_PORT,
          "user_name":"CRYPTONIGHT_BASED_COIN_WALLET_ADDRESS"
      }
  }

}
```

It is usefull when you have multiple rigs and want to quickly switch to a new algo for spec minig purposes.
I’ve also added the beta [xmrig-nvidia](https://github.com/xmrig/xmrig-nvidia/tree/feature-cryptonight-heavy) in `/home/m1/xmr/xmrig-nvidia/` folder for the `Cryptonight-Heavy` algo (haven, sumokoin) in the config file.
