### PR TITLE
Restore tempcontrol reactivity when telegram alerts are enabled

### DIFF
--- a/1bash
+++ b/1bash
@@ -271,7 +271,7 @@ WATCHDOG_CYCLE="15"         # Time between watchdog cycle loops to check GPU uti
 
 WATCHDOG_USE_COLOR="NO"     # Watchdog log beautifier, use bold text and colors
 
-GPU_UTIL_THRESHOLD="80"     # GPU utilization threshold, If utilization bellow this value watchdog takes action (Recomended values 70-90) 
+GPU_UTIL_THRESHOLD="70"     # GPU utilization threshold, If utilization bellow this value watchdog takes action (Recomended values 70-90) 
 
 ALT_POOL="NO"               # YES or NO, Set to YES if you want to enable  poolswitch. 
                             # Switch to alternate pool if main pool goes down.

--- a/5watchdog
+++ b/5watchdog
@@ -224,7 +224,7 @@ do
         sudo reboot
       elif (( UTIL < THRESHOLD )) # If utilization is lower than threshold, decrement counter
       then
-        echo "$(date) - [WARNING] - GPU${GPU} under ${THRESHOLD}% threshold - UTILIZATION: ${UTIL}%"" | tee -a ${LOG_FILE}
+        echo "$(date) - [WARNING] - GPU${GPU} under ${THRESHOLD}% threshold - UTILIZATION: ${UTIL}%" | tee -a ${LOG_FILE}
         COUNT=$((COUNT - 1))
         NUM_GPU_BLW_THRSHLD=$((NUM_GPU_BLW_THRSHLD + 1))
       fi

--- a/5watchdog
+++ b/5watchdog
@@ -224,7 +224,7 @@ do
         sudo reboot
       elif (( UTIL < THRESHOLD )) # If utilization is lower than threshold, decrement counter
       then
-        echo "$(date) - [WARNING] - GPU$GPU under threshold - GPU$GPU UTILIZATION: $UTIL%" | tee -a ${LOG_FILE}
+        echo "$(date) - [WARNING] - GPU${GPU} under ${THRESHOLD}% threshold - UTILIZATION: ${UTIL}%"" | tee -a ${LOG_FILE}
         COUNT=$((COUNT - 1))
         NUM_GPU_BLW_THRSHLD=$((NUM_GPU_BLW_THRSHLD + 1))
       fi
@@ -244,7 +244,7 @@ do
         sudo reboot
       elif (( UTIL < THRESHOLD )) # If utilization is lower than threshold, decrement counter
       then
-        echo "$(date) - [WARNING] - GPU${GPU} under threshold - GPU${GPU} UTILIZATION: ${UTIL}%" | tee -a ${LOG_FILE}
+        echo "$(date) - [WARNING] - GPU${GPU} under ${THRESHOLD}% threshold - UTILIZATION: ${UTIL}%" | tee -a ${LOG_FILE}
         COUNT=$((COUNT - 1))
         NUM_GPU_BLW_THRSHLD=$((NUM_GPU_BLW_THRSHLD + 1))
       fi

--- a/6tempcontrol
+++ b/6tempcontrol
@@ -239,7 +239,7 @@ while true; do
         while [ $ERR_TIMER -gt 0 ]; do
           echo -e "${R}${B}WARNING: $(date) - Problem detected! GPU$GPU is not responding. Will give watchdog $ERR_TIMER seconds to react, if not we will reboot!${N}" | tee -a ${LOG_FILE}
           if [[ $TELEGRAM_ALERTS == "YES" ]]; then
-            bash "${NVOC}/telegram"
+            bash "${NVOC}/telegram" &
           fi
           sleep 15
           { IFS=', ' read CURRENT_TEMP CURRENT_FAN PWRLIMIT; } < <(nvidia-smi -i $GPU --query-gpu=temperature.gpu,fan.speed,power.limit --format=csv,noheader,nounits)
@@ -265,7 +265,7 @@ while true; do
         while [ $ERR_TIMER -gt 0 ]; do
           echo -e "${R}${B}WARNING: $(date) - Problem detected! GPU$GPU is not responding. Will give watchdog $ERR_TIMER seconds to react, if not we will reboot!${N}" | tee -a ${LOG_FILE}
           if [[ $TELEGRAM_ALERTS == "YES" ]]; then
-            bash "${NVOC}/telegram"
+            bash "${NVOC}/telegram" &
           fi
           sleep 15
           { IFS=', ' read CURRENT_TEMP CURRENT_FAN PWRLIMIT POWERDRAW; } < <(nvidia-smi -i $GPU --query-gpu=temperature.gpu,fan.speed,power.limit,power.draw --format=csv,noheader,nounits)
@@ -278,7 +278,7 @@ while true; do
           if [ $ERR_TIMER -le 0 ]; then
             echo -e "${R}${B}WARNING: $(date) - Problem detected with GPU$GPU. Watchdog didn't react. System will reboot by the TEMP_CONTROL to correct the problem!" | tee -a ${LOG_FILE} ${WD_LOG_FILE}
             if [[ $TELEGRAM_ALERTS == "YES" ]]; then
-              bash "${NVOC}/telegram"
+              bash "${NVOC}/telegram" &
             fi
             sleep 3
             sudo reboot
@@ -307,7 +307,7 @@ while true; do
         # Fan speed reached MAXIMAL_FAN_SPEED, we have to drop the power limit
         echo -e "${B}WARNING: GPU $GPU${N}, ${R}$(date) - Fan speed reached $MAXIMAL_FAN_SPEED, dropping Power Limit in order to maintain the desired temp${N}" | tee -a ${LOG_FILE}
         if [[ $TELEGRAM_ALERTS == "YES" ]]; then
-          bash "${NVOC}/telegram"
+          bash "${NVOC}/telegram" &
         fi
         NEW_POWER_LIMIT=$(($POWERLIMIT - $POWER_ADJUST))
         echo -e "${B}WARNING: GPU $GPU${N}, ${R}$(date) - Adjusting Power Limit for ${B}GPU$GPU${N}${R}. Old Limit: ${B}$POWERLIMIT${N}${R} New Limit: ${B}$NEW_POWER_LIMIT${N}${R} Fan speed: ${B}$NEW_FAN_SPEED${N}" | tee -a ${LOG_FILE}


### PR DESCRIPTION
This is a subset of changes I already have in my working tree which I think they need to be merged asap. Basically, when telegram alerts are enabled it was slowing down tempcontrol reactivity in such a way that power throttling occurred because of slow fans, and gpu utilizations went down enough to let watchdog cause a restart/reboot loop. 