### PR TITLE
Force checkout on miners-upgrade

### DIFF
--- a/nvOC
+++ b/nvOC
@@ -924,7 +924,7 @@ Reset()
 MinersUpgrade()
 {
   echo "Checking for nvOC miners updates..."
-  git -C ${NVOC} submodule update --init --depth 1 --remote miners
+  git -C ${NVOC} submodule update --init --force --depth 1 --remote miners
 
   echo "Running updates installer"
   pushd .


### PR DESCRIPTION
The nvOC miners-upgrade is meant to be used by non-expert users. The --force flag prevents them to see errors for (probably unintentional) conflicting changes on release branch. This also allows this command to be used for recovery of consistent miners repo state.