### PR TITLE
Removed double quotes from GPUPowerMizerMode

### DIFF
--- a/3main
+++ b/3main
@@ -899,7 +899,7 @@ then
   gpu=0
   while (( gpu < GPUS ))
   do
-    NVD_SETTINGS="${NVD_SETTINGS} -a [gpu:$gpu]/GPUPowerMizerMode=\"${GPUPowerMizerMode}\""
+    NVD_SETTINGS="${NVD_SETTINGS} -a [gpu:$gpu]/GPUPowerMizerMode=${GPUPowerMizerMode}"
     gpu=$((gpu+1))
   done
 fi


### PR DESCRIPTION
GPUPowerMizerMode will not set correctly with the double quotes in place.
Note* There weren't double quote in 19-2.0