### PR TITLE
Create 4nvOC_watch

### DIFF
--- a/4nvOC_watch
+++ b/4nvOC_watch
@@ -1,0 +1,92 @@
+#!/bin/bash
+# 4nvOC_watch to monitor nvOC running scripts
+
+v0001="papampi; Initial release"
+
+source ${NVOC}/1bash
+nvOC_4nvOC_watch_Dev="0001"
+nvOC_4nvOC_watch_ver="$nvOC_ver.$nvOC_4nvOC_watch_Dev"                
+
+echo "Starting nvOC Watch to monitor nvOC scripts in 60 seconds"
+sleep 60
+
+# Infinite Loop
+while true
+do
+  source ${NVOC}/1bash
+  echo "$(date) Check nvOC scripts"
+
+  if ! ps ax | grep -q "[3]main"
+  then
+    echo "3main is not running, checking 2unix"
+    if ! ps ax | grep -q "[2]unix"
+    then
+      echo "$(date) - 2unix stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+      bash ${NVOC}/bash nvOC restart
+    fi
+  else
+    echo "3main running"
+  fi
+
+  if [[ $MINER_WATCHDOG == "YES" ]]
+  then
+    if ! ps ax | grep "[5]watchdog"
+    then
+      echo "watchdog stopped running, check again in 30"
+      sleep 30
+      if ! ps ax | grep "[5]watchdog"
+      then
+        echo "$(date) - watchdog stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+        screen -c ${NVOC}/screenrc-watchdog -dmSL wdog bash ${NVOC}/5watchdog
+      fi
+    else
+      echo "WatchDog running ok"
+    fi
+  else
+    echo "Watchdog disabled"
+    pkill -f 5watchdog
+  fi
+
+  if [[ $MINER_TEMP_CONTROL == "YES" ]]
+  then
+    if ! ps ax | grep "[6]tempcontrol"
+    then
+      echo "tempcontrol stopped running, check again in 30"
+      sleep 30
+      if ! ps ax | grep "[6]tempcontrol"
+      then
+        echo "$(date) - tempcontrol stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/6_autotemplog
+        screen -c ${NVOC}/screenrc-tempcontrol -dmSL temp bash ${NVOC}/6tempcontrol
+      fi
+    else
+      echo "Temp Control running ok"
+    fi
+  else
+    echo "Temp control disabled"
+    pkill -f 6tempcontrol
+  fi
+
+  if [[ $AUTO_SWITCH == WTM_SWITCHING ]]
+  then
+    if ! ps ax | grep -q "[8]wtm_auto_switch"
+    then
+      echo "wtm stopped running, check again in 30"
+      sleep 30
+      if ! ps ax | grep -q "[8]wtm_auto_switch"
+      then
+        echo "$(date) - wtm stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+        screen -c ${NVOC}/screenrc-wtm -dmSL wtm bash ${NVOC}/8wtm_auto_switch
+      fi
+    else
+      echo "WTM Auto Switch running ok"
+    fi
+  else
+    echo "WTM Auto Switch disabled"
+    pkill -f 8wtm_auto_switch
+  fi
+  
+  echo "Check again in 5 min"
+  echo " "
+  sleep 300
+
+done

--- a/4nvOC_watch
+++ b/4nvOC_watch
@@ -15,55 +15,66 @@ while true
 do
   source ${NVOC}/1bash
   echo "$(date) Check nvOC scripts"
-
-  if ! ps ax | grep -q "[3]main"
+  echo "Exit/Close this guake tab if you want to close gnome-terminal and stop mining"
+  echo ""
+  
+  if [[ $AUTO_START_MINER == "YES" ]]
   then
-    echo "3main is not running, checking 2unix"
-    if ! ps ax | grep -q "[2]unix"
+    if ! ps ax | grep -q "[3]main"
     then
-      echo "$(date) - 2unix stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
-      bash ${NVOC}/nvOC restart
+      echo "3main is not running, checking 2unix"
+      if ! ps ax | grep -q "[2]unix"
+      then
+        echo "$(date) - 2unix stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+        bash ${NVOC}/nvOC restart
+      fi
+    else
+      echo "3main running"
     fi
-  else
-    echo "3main running"
   fi
-
+  
   if [[ $MINER_WATCHDOG == "YES" ]]
   then
-    if ! ps ax | grep "[5]watchdog"
+    if ! ps ax | grep -q "[5]watchdog"
     then
       echo "watchdog stopped running, check again in 30"
       sleep 30
-      if ! ps ax | grep "[5]watchdog"
+      if ! ps ax | grep -q "[5]watchdog"
       then
         echo "$(date) - watchdog stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
         screen -c ${NVOC}/screenrc-watchdog -dmSL wdog bash ${NVOC}/5watchdog
       fi
     else
-      echo "WatchDog running ok"
+      echo "WatchDog running"
     fi
   else
     echo "Watchdog disabled"
-    pkill -f 5watchdog
+    if ps ax | grep -q "[5]watchdog"
+    then
+      pkill -f 5watchdog
+    fi
   fi
 
   if [[ $MINER_TEMP_CONTROL == "YES" ]]
   then
-    if ! ps ax | grep "[6]tempcontrol"
+    if ! ps ax | grep -q "[6]tempcontrol"
     then
       echo "tempcontrol stopped running, check again in 30"
       sleep 30
-      if ! ps ax | grep "[6]tempcontrol"
+      if ! ps ax | grep -q "[6]tempcontrol"
       then
         echo "$(date) - tempcontrol stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/6_autotemplog
         screen -c ${NVOC}/screenrc-tempcontrol -dmSL temp bash ${NVOC}/6tempcontrol
       fi
     else
-      echo "Temp Control running ok"
+      echo "Temp Control running"
     fi
   else
     echo "Temp control disabled"
-    pkill -f 6tempcontrol
+    if ps ax | grep -q "[6]tempcontrol"
+    then
+      pkill -f 6tempcontrol
+    fi
   fi
 
   if [[ $AUTO_SWITCH == WTM_SWITCHING ]]
@@ -78,11 +89,13 @@ do
         screen -c ${NVOC}/screenrc-wtm -dmSL wtm bash ${NVOC}/8wtm_auto_switch
       fi
     else
-      echo "WTM Auto Switch running ok"
+      echo "WTM Auto Switch running"
     fi
   else
     echo "WTM Auto Switch disabled"
-    pkill -f 8wtm_auto_switch
+    if ps ax | grep -q "[8]wtm_auto_switch"
+    then
+      pkill -f 8wtm_auto_switch
   fi
   
   echo "Check again in 5 min"

--- a/4nvOC_watch
+++ b/4nvOC_watch
@@ -96,6 +96,7 @@ do
     if ps ax | grep -q "[8]wtm_auto_switch"
     then
       pkill -f 8wtm_auto_switch
+    fi
   fi
   
   echo "Check again in 5 min"

--- a/4nvOC_watch
+++ b/4nvOC_watch
@@ -22,7 +22,7 @@ do
     if ! ps ax | grep -q "[2]unix"
     then
       echo "$(date) - 2unix stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
-      bash ${NVOC}/bash nvOC restart
+      bash ${NVOC}/nvOC restart
     fi
   else
     echo "3main running"

--- a/4nvOC_watch
+++ b/4nvOC_watch
@@ -5,21 +5,22 @@ v0001="papampi; Initial release"
 
 source ${NVOC}/1bash
 nvOC_4nvOC_watch_Dev="0001"
-nvOC_4nvOC_watch_ver="$nvOC_ver.$nvOC_4nvOC_watch_Dev"                
+nvOC_4nvOC_watch_ver="$nvOC_ver.$nvOC_4nvOC_watch_Dev"
 
-echo "Starting nvOC Watch to monitor nvOC scripts in 60 seconds"
-sleep 60
 
-# Infinite Loop
-while true
-do
-  source ${NVOC}/1bash
-  echo "$(date) Check nvOC scripts"
-  echo "Exit/Close this guake tab if you want to close gnome-terminal and stop mining"
-  echo ""
-  
-  if [[ $AUTO_START_MINER == "YES" ]]
-  then
+if [[ $AUTO_START_MINER == YES ]]
+then
+  echo "Starting nvOC Watch to monitor nvOC scripts in 60 seconds"
+  sleep 60
+
+  # Infinite Loop
+  while true
+  do
+    source ${NVOC}/1bash
+    echo "$(date) Check nvOC scripts"
+    echo "Exit/Close this guake tab if you want to close gnome-terminal and stop mining"
+    echo ""
+
     if ! ps ax | grep -q "[3]main"
     then
       echo "3main is not running, checking 2unix"
@@ -31,76 +32,76 @@ do
     else
       echo "3main running"
     fi
-  fi
-  
-  if [[ $MINER_WATCHDOG == "YES" ]]
-  then
-    if ! ps ax | grep -q "[5]watchdog"
+
+    if [[ $MINER_WATCHDOG == YES ]]
     then
-      echo "watchdog stopped running, check again in 30"
-      sleep 30
       if ! ps ax | grep -q "[5]watchdog"
       then
-        echo "$(date) - watchdog stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
-        screen -c ${NVOC}/screenrc-watchdog -dmSL wdog bash ${NVOC}/5watchdog
+        echo "watchdog stopped running, check again in 30"
+        sleep 30
+        if ! ps ax | grep -q "[5]watchdog"
+        then
+          echo "$(date) - watchdog stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+          screen -c ${NVOC}/screenrc-watchdog -dmSL wdog bash ${NVOC}/5watchdog
+        fi
+      else
+        echo "WatchDog running"
       fi
     else
-      echo "WatchDog running"
+      echo "Watchdog disabled"
+      if ps ax | grep -q "[5]watchdog"
+      then
+        pkill -f 5watchdog
+      fi
     fi
-  else
-    echo "Watchdog disabled"
-    if ps ax | grep -q "[5]watchdog"
-    then
-      pkill -f 5watchdog
-    fi
-  fi
 
-  if [[ $MINER_TEMP_CONTROL == "YES" ]]
-  then
-    if ! ps ax | grep -q "[6]tempcontrol"
+    if [[ $MINER_TEMP_CONTROL == YES ]]
     then
-      echo "tempcontrol stopped running, check again in 30"
-      sleep 30
       if ! ps ax | grep -q "[6]tempcontrol"
       then
-        echo "$(date) - tempcontrol stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/6_autotemplog
-        screen -c ${NVOC}/screenrc-tempcontrol -dmSL temp bash ${NVOC}/6tempcontrol
+        echo "tempcontrol stopped running, check again in 30"
+        sleep 30
+        if ! ps ax | grep -q "[6]tempcontrol"
+        then
+          echo "$(date) - tempcontrol stopped running, restarting it" | tee -a  ${NVOC}/nvoc_logs/6_autotemplog
+          screen -c ${NVOC}/screenrc-tempcontrol -dmSL temp bash ${NVOC}/6tempcontrol
+        fi
+      else
+        echo "Temp Control running"
       fi
     else
-      echo "Temp Control running"
+      echo "Temp control disabled"
+      if ps ax | grep -q "[6]tempcontrol"
+      then
+        pkill -f 6tempcontrol
+      fi
     fi
-  else
-    echo "Temp control disabled"
-    if ps ax | grep -q "[6]tempcontrol"
-    then
-      pkill -f 6tempcontrol
-    fi
-  fi
 
-  if [[ $AUTO_SWITCH == WTM_SWITCHING ]]
-  then
-    if ! ps ax | grep -q "[8]wtm_auto_switch"
+    if [[ $AUTO_SWITCH == WTM_SWITCHING ]]
     then
-      echo "wtm stopped running, check again in 30"
-      sleep 30
       if ! ps ax | grep -q "[8]wtm_auto_switch"
       then
-        echo "$(date) - wtm stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
-        screen -c ${NVOC}/screenrc-wtm -dmSL wtm bash ${NVOC}/8wtm_auto_switch
+        echo "wtm stopped running, check again in 30"
+        sleep 30
+        if ! ps ax | grep -q "[8]wtm_auto_switch"
+        then
+          echo "$(date) - wtm stopped running, restarting it"  | tee -a  ${NVOC}/nvoc_logs/5_watchdoglog
+          screen -c ${NVOC}/screenrc-wtm -dmSL wtm bash ${NVOC}/8wtm_auto_switch
+        fi
+      else
+        echo "WTM Auto Switch running"
       fi
     else
-      echo "WTM Auto Switch running"
+      echo "WTM Auto Switch disabled"
+      if ps ax | grep -q "[8]wtm_auto_switch"
+      then
+        pkill -f 8wtm_auto_switch
+      fi
     fi
-  else
-    echo "WTM Auto Switch disabled"
-    if ps ax | grep -q "[8]wtm_auto_switch"
-    then
-      pkill -f 8wtm_auto_switch
-    fi
-  fi
-  
-  echo "Check again in 5 min"
-  echo " "
-  sleep 300
 
-done
+    echo "Check again in 5 min"
+    echo " "
+    sleep 300
+
+  done
+fi


### PR DESCRIPTION
Some times I noticed some nvOC scripts has been stopped running and there is no script to monitor if they are running or not.
It mostly happening on my test rig with gnome-terminal (2unix) and watchdog stopped, also happened once or twice on some of my other rigs as well.

No idea whats the problem that closes gnome-terminal.
Any better ideas ?

It also needs an entry in 1bash and 3main...