### PR TITLE
nvOC restart rework

### DIFF
--- a/3main
+++ b/3main
@@ -99,7 +99,7 @@ then
   then
     sudo teamviewer --daemon enable
     sleep 2
-    guake -n teamviewer -r teamviewer -e "teamviewer"
+    guake -n teamviewer -r teamviewer -e "teamviewer" &
     running=""
   fi
 fi
@@ -130,7 +130,7 @@ then
   sleep 2
   HCD=${NVOC}/SRR
   if ! ps ax | grep -q '[S]RR';  then
-    guake -n $HCD -r SRR -e "bash ${NVOC}/SRR"
+    guake -n $HCD -r SRR -e "bash ${NVOC}/SRR" &
   fi
 fi
 
@@ -146,7 +146,7 @@ then
   HCD="${NVOC}/log_rotate"
   if ! ps ax | grep -q '[l]og_rotate'
   then
-    guake -n $HCD -r LOG_ROTATE -e "bash ${NVOC}/log_rotate"
+    guake -n $HCD -r LOG_ROTATE -e "bash ${NVOC}/log_rotate" &
   fi
 fi
 
@@ -339,7 +339,7 @@ then
   then
     if [[ $LOCALorREMOTE == LOCAL ]]
     then
-      guake -n $HCD -r plusCPU -e "$HCD -a cryptonightv7 -o stratum+tcp://$XMR_POOL:$XMR_PORT -u $XMRADDR -p x -t $threadCOUNT"
+      guake -n $HCD -r plusCPU -e "$HCD -a cryptonightv7 -o stratum+tcp://$XMR_POOL:$XMR_PORT -u $XMRADDR -p x -t $threadCOUNT" &
     else
       screen -c ${NVOC}/screenrc-miner -dmS plusCPU $HCD -a cryptonightv7 -o stratum+tcp://$XMR_POOL:$XMR_PORT -u $XMRADDR -p x -t $threadCOUNT
     fi
@@ -355,7 +355,7 @@ then
   HCD="${NVOC}/7reboot"
   if ! ps ax | grep -q '[7]reboot'
   then
-    guake -n $HCD -r AUTO_REBOOT -e "bash ${NVOC}/7reboot"
+    guake -n $HCD -r AUTO_REBOOT -e "bash ${NVOC}/7reboot" &
   fi
 fi
 
@@ -370,7 +370,7 @@ then
     echo ""
     echo "process in guake terminal Tab (f12)"
     echo ""
-    guake -n $HCD -r PX_LP_upPASTE -e "bash ${NVOC}/upPASTE"
+    guake -n $HCD -r PX_LP_upPASTE -e "bash ${NVOC}/upPASTE" &
   fi
 fi
 
@@ -391,7 +391,7 @@ then
       echo "process in screen temp, guake terminal Tab (f12), 'nvOC temp-log'"
       #if guake tab is already showing temp control output dont open a new one
       if ! ps ax | grep "tail -n 0 -f ${NVOC}/nvoc_logs/[t]empcontrol-screenlog.0"; then
-        guake -n ${NVOC}/6tempcontrol -r MINER_TEMP_CONTROL -e "tail -n 0 -f ${NVOC}/nvoc_logs/tempcontrol-screenlog.0"
+        guake -n ${NVOC}/6tempcontrol -r MINER_TEMP_CONTROL -e "tail -n 0 -f ${NVOC}/nvoc_logs/tempcontrol-screenlog.0" &
       fi
     elif [[ $LOCALorREMOTE == REMOTE ]]; then
       echo "process in screen temp; 'nvOC temp-log'"
@@ -405,7 +405,7 @@ then
   HCD="${NVOC}/7telegram"
   if ! ps ax | grep -q '[7]telegram'
   then
-    guake -n $HCD -r TELEGRAM_MESSAGES -e "bash ${NVOC}/7telegram"
+    guake -n $HCD -r TELEGRAM_MESSAGES -e "bash ${NVOC}/7telegram" &
     running=""
   fi
 fi
@@ -433,7 +433,7 @@ EOF
   HCD="${NVOC}/8wtm_profit_check"
   if ! ps ax | grep -q '[8]wtm_profit_check'
   then
-    guake -n $HCD -r WTM_PROFIT_CHECK -e "bash ${NVOC}/8wtm_profit_check"
+    guake -n $HCD -r WTM_PROFIT_CHECK -e "bash ${NVOC}/8wtm_profit_check" &
     running=""
   fi
 fi
@@ -781,7 +781,7 @@ EOF
       echo ""
       echo "process in screen wtm, guake terminal Tab (f12)"
       if ! ps ax | grep "tail -n 0 -f ${NVOC}/nvoc_logs/[8]_wtmautoswitchlog"; then
-        guake -n ${NVOC}/8wtm_auto_switch -r WTM_SWITCHING -e "tail -n 0 -f ${NVOC}/nvoc_logs/8_wtmautoswitchlog"
+        guake -n ${NVOC}/8wtm_auto_switch -r WTM_SWITCHING -e "tail -n 0 -f ${NVOC}/nvoc_logs/8_wtmautoswitchlog" &
       fi
     elif [[ $LOCALorREMOTE == REMOTE ]]; then
       echo "process in screen wtm, 'nvOC wtm-log'"
@@ -801,7 +801,7 @@ then
     screen -dmS eth_pill sudo $HCD
     if [[ $LOCALorREMOTE == LOCAL ]]
     then
-      guake -n $HCD -r ETH_PILL -e "screen -r eth_pill"
+      guake -n $HCD -r ETH_PILL -e "screen -r eth_pill" &
     fi
   fi
 else
@@ -938,7 +938,7 @@ then
         echo "process in screen wdog, guake terminal Tab (f12), 'nvOC wdog-log'"
         #if guake tab is already showing watchdog output dont open a new one
         if [[ ! $(ps ax | grep "tail -f ${NVOC}/nvoc_logs/watchdog-screenlog.0" |grep -v grep) ]];then
-          guake -n ${NVOC}/5watchdog -r MINER_WATCHDOG -e "tail -f  ${NVOC}/nvoc_logs/watchdog-screenlog.0 "
+          guake -n ${NVOC}/5watchdog -r MINER_WATCHDOG -e "tail -f  ${NVOC}/nvoc_logs/watchdog-screenlog.0" &
         fi
         echo ""
       elif [[ $LOCALorREMOTE == REMOTE ]]
@@ -999,7 +999,7 @@ then
       if [[ $LOCALorREMOTE == LOCAL ]]
       then
         if ! ps ax | grep "tail -n 0 -f ${NVOC}/nvoc_logs/[s]creenlog.0" ; then
-          guake -n 1 -r AUTO_SWITCH  -e "tail -n 0 -f ${NVOC}/nvoc_logs/screenlog.0"
+          guake -n 1 -r AUTO_SWITCH  -e "tail -n 0 -f ${NVOC}/nvoc_logs/screenlog.0" &
         fi
         echo "mining process in Guake Tab"
         echo ""

--- a/5watchdog
+++ b/5watchdog
@@ -438,7 +438,7 @@ do
           POOL=0
           if [[ $ALT_POOL == YES ]] && [[ -n ${!COIN_POOL_2} ]]
           then
-            guake -n 9poolswitch -r POOL_SWITCH -e "bash ${NVOC}/9poolswitch"
+            guake -n 9poolswitch -r POOL_SWITCH -e "bash ${NVOC}/9poolswitch" &
             sleep 300
           else
             while !  nc -vzw1 ${!COIN_POOL} ${!COIN_PORT} ;   do

--- a/nvOC
+++ b/nvOC
@@ -946,6 +946,9 @@ Environment=NVOC=${NVOC}
 WorkingDirectory=${NVOC}
 ExecStart=/usr/bin/screen -c ${NVOC}/screenrc-main -dmSL main /bin/bash "${NVOC}/2unix"
 Restart=always
+
+[Install]
+WantedBy=graphical.target
 EOF
 
   if sudo systemd-analyze verify nvoc.service

--- a/nvOC
+++ b/nvOC
@@ -235,8 +235,8 @@ Reboot()
   sudo su -c "shutdown -r now"
 }
 
-############################### Start nvOC ####################################
-Start()
+############################### Start nvOC in gnome-terminal ##################
+StartGnomeTerminal()
 {
   if [[ $LOCALorREMOTE == REMOTE ]]
   then
@@ -252,7 +252,7 @@ Start()
 }
 
 ############################### Stop nvOC #####################################
-Stop()
+StopGnomeTerminal()
 {
   echo -e "${B}Stopping nvOC processes...${N}"; echo
 
@@ -270,7 +270,14 @@ Stop()
 Restart()
 {
    # Restart nvOC from scratch
-   Stop && Start
+   # if systemctl is-enabled nvoc.service
+   # then
+   # # nvOC as systemd service
+   # StopService && StartService
+   # else
+   # # nvOC in gnome-terminal
+   StopGnomeTerminal && StartGnomeTerminal
+   # fi
 }
 
 ############################### gpumap ########################################
@@ -1051,8 +1058,8 @@ case $# in
       report)              Report;;
       patch)               Patch;;
       reboot)              Reboot;;
-      start)               Start;;
-      stop)                Stop;;
+      start)               StartGnomeTerminal;;
+      stop)                StopGnomeTerminal;;
       restart)             Restart;;
       restore)             Restore;;
       upgrade)             Upgrade;;

--- a/nvOC
+++ b/nvOC
@@ -251,7 +251,7 @@ StartGnomeTerminal()
   fi
 }
 
-############################### Stop nvOC #####################################
+############################### Stop nvOC in gnome-terminal ###################
 StopGnomeTerminal()
 {
   echo -e "${B}Stopping nvOC processes...${N}"; echo

--- a/nvOC
+++ b/nvOC
@@ -270,14 +270,14 @@ StopGnomeTerminal()
 Restart()
 {
    # Restart nvOC from scratch
-   # if systemctl is-enabled nvoc.service
-   # then
-   # # nvOC as systemd service
-   # StopService && StartService
-   # else
-   # # nvOC in gnome-terminal
-   StopGnomeTerminal && StartGnomeTerminal
-   # fi
+   if systemctl is-enabled nvoc.service
+   then
+     # nvOC as systemd service
+     StopService && StartService
+   else
+     # nvOC in gnome-terminal
+     StopGnomeTerminal && StartGnomeTerminal
+   fi
 }
 
 ############################### gpumap ########################################

--- a/nvOC
+++ b/nvOC
@@ -425,15 +425,7 @@ GPUmap()
         echo -e "Acknowledged. Thank you for using ${B}gpumap${N}"
         echo "Resuming mining operation now..."
         echo ""
-        if [[ $LOCALorREMOTE == LOCAL ]]
-        then
-          gnome-terminal
-          exit
-        else
-          echo "REMOTE setting in 1bash detected."
-          echo "To resume mining we have to reboot the rig"
-          Reboot
-        fi
+        Restart
       else
         echo "Neither y or n were pressed!"
         echo "Lets try this again..."
@@ -450,15 +442,7 @@ GPUmap()
           ${NVD} -a [gpu:${count}]/GPULogoBrightness=0 >/dev/null 2>&1
           echo -e "Thank you for using ${B}gpumap${N}"
           echo "Resuming mining operation now."
-          if [[ $LOCALorREMOTE == LOCAL ]]
-          then
-            gnome-terminal
-            exit
-          else
-            echo "REMOTE setting in 1bash detected."
-            echo "To resume mining we have to reboot the rig"
-            Reboot
-          fi
+          Restart
         fi
       fi
       echo; echo
@@ -477,15 +461,7 @@ GPUmap()
 
   if [[ $response =~ ^[Yy]$ ]]
   then
-    if [[ $LOCALorREMOTE == LOCAL ]]
-    then
-      gnome-terminal
-      exit
-    else
-      echo "REMOTE setting in 1bash detected."
-      echo "To resume mining we have to reboot the rig"
-      Reboot
-    fi
+    Restart
   fi
 }
 

--- a/upPASTE
+++ b/upPASTE
@@ -35,28 +35,7 @@ then
   echo "1bash updated from paste: $pasteBASH"
   echo ""
   sleep 2
-  if [ $LOCALorREMOTE == "LOCAL" ];then
-     # Kill off the nv_OC processes
-     pkill -f gnome-terminal
-     pkill -f 5watchdog
-     pkill -f 6tempcontrol
-     pkill -f 7telegram
-     pkill -e screen
-     pkill -f 8wtm
-     gnome-terminal -e "bash ${NVOC}/3main"
-     echo -e "${B}Miner Restart....${N}"; echo ""
-  else
-     # Kill off the nv_OC processes
-     pkill -f gnome-terminal
-     pkill -f 5watchdog
-     pkill -f 7telegram
-     pkill -f 6tempcontrol
-     pkill -e screen
-     pkill -f 8wtm
-     export DISPLAY=:0
-     gnome-terminal -e "bash ${NVOC}/3main"
-     echo -e "${B}Miner Restart....${N}"; echo ""
-  fi
+  bash ${NVOC}/nvOC restart
 fi
 
 if [ $change == "NO" ]


### PR DESCRIPTION
- if guake fails 3main and other nvOC scripts does not get stuck
- gnome-terminal restart fixed in old code chunks
- nvOC restart will work either with gnome-terminal and systemd

note: if you did execute `nvOC install-service` in the past on your machine, the `nvOC restart` command will now try to restart nvOC as a service even if it is disabled due to an incomplete existing service setup, This issue is resolved by simply reinstalling the service again with `nvOC install-service` and then disabling it with `sudo systemctl disable nvoc`.