### PR TITLE
Consistent fallbacks for undefined oc & pl settings

### DIFF
--- a/1bash.template
+++ b/1bash.template
@@ -252,7 +252,7 @@ WATCHDOG_CYCLE="15"         # Time between watchdog cycle loops to check GPU uti
 
 WATCHDOG_USE_COLOR="NO"     # Watchdog log beautifier, use bold text and colors
 
-GPU_UTIL_THRESHOLD="70"     # GPU utilization threshold, If utilization bellow this value watchdog takes action (Recomended values 70-90) 
+GPU_UTIL_THRESHOLD="70"     # GPU utilization threshold, If utilization bellow this value watchdog takes action (Recommended values 70-90) 
 	    
 HIGH_LOAD_REBOOT="NO"       # YES or NO, Set to YES if you want watchdog reboot when all load averages (1 min, 5 min and 15 min) goes over double the CPU cores.
                             # This option uses sysrq_reboot to reboot the rig.
@@ -1302,148 +1302,178 @@ MEMORY_OVERCLOCK_18=100
 ########################################################
 
 # OC settings used according to current mining ALGO
-# Deafault values are for 1060 check http://krypto-mining.blogspot.co.uk/ for other OC values
+
+# Uppercase algos are those used for single coin mining (no auto switch) and by WTM switcher
 # Lowercase algos are those used by all salfter-based switchers
-# Uppercase algos are those used for single coin mining and by WTM switcher
+
+# For any missing algo settings the following fallback policy is applied:
+#   *_POWERLIMIT_WATTS defaults to global POWERLIMIT_WATTS value
+#   *_*_OVERCLOCK defaults both algo specific OC offsets to 0
+
+# Recommended values are for 1060 check http://krypto-mining.blogspot.co.uk/ for other OC values
 
 # BITCORE, TIMETRAVEL10
-BITCORE_POWERLIMIT_WATTS=100        # Recomended value for some GTX-1060: 65
-BITCORE_CORE_OVERCLOCK=0            # Recomended value for some GTX-1060: 150
-BITCORE_MEMORY_OVERCLOCK=0          # Recomended value for some GTX-1060: 800
+BITCORE_POWERLIMIT_WATTS=100               # Recommended value for some GTX-1060: 65
+BITCORE_CORE_OVERCLOCK=0                 # Recommended value for some GTX-1060: 150
+BITCORE_MEMORY_OVERCLOCK=0               # Recommended value for some GTX-1060: 800
 
 # Cryptonight
-CRYPTONIGHT_POWERLIMIT_WATTS=100           # Recomended value for some GTX-1060: 62
-CRYPTONIGHT_CORE_OVERCLOCK=0             # Recomended value for some GTX-1060: 155
-CRYPTONIGHT_MEMORY_OVERCLOCK=0           # Recomended value for some GTX-1060: -300
+CRYPTONIGHT_POWERLIMIT_WATTS=100           # Recommended value for some GTX-1060: 62
+CRYPTONIGHT_CORE_OVERCLOCK=0             # Recommended value for some GTX-1060: 155
+CRYPTONIGHT_MEMORY_OVERCLOCK=0           # Recommended value for some GTX-1060: -300
 
 # CRYPTONIGHTV7
-CRYPTONIGHTV7_POWERLIMIT_WATTS=100           # Recomended value for some GTX-1060: 62
-CRYPTONIGHTV7_CORE_OVERCLOCK=0             # Recomended value for some GTX-1060: 155
-CRYPTONIGHTV7_MEMORY_OVERCLOCK=0           # Recomended value for some GTX-1060: -300
+CRYPTONIGHTV7_POWERLIMIT_WATTS=100         # Recommended value for some GTX-1060: 62
+CRYPTONIGHTV7_CORE_OVERCLOCK=0           # Recommended value for some GTX-1060: 155
+CRYPTONIGHTV7_MEMORY_OVERCLOCK=0         # Recommended value for some GTX-1060: -300
 
 # CRYPTONIGHT HEAVY
-CRYPTONIGHTHEAVY_POWERLIMIT_WATTS=100           # Recomended value for some GTX-1060: 62
-CRYPTONIGHTHEAVY_CORE_OVERCLOCK=0             # Recomended value for some GTX-1060: 155
-CRYPTONIGHTHEAVY_MEMORY_OVERCLOCK=0           # Recomended value for some GTX-1060: -300
+CRYPTONIGHTHEAVY_POWERLIMIT_WATTS=100      # Recommended value for some GTX-1060: 62
+CRYPTONIGHTHEAVY_CORE_OVERCLOCK=0        # Recommended value for some GTX-1060: 155
+CRYPTONIGHTHEAVY_MEMORY_OVERCLOCK=0      # Recommended value for some GTX-1060: -300
 
 # Equihash
-EQUIHASH_POWERLIMIT_WATTS=100              # Recomended value for some GTX-1060: 76
-EQUIHASH_CORE_OVERCLOCK=0                # Recomended value for some GTX-1060: 150
-EQUIHASH_MEMORY_OVERCLOCK=0              # Recomended value for some GTX-1060: 400
+EQUIHASH_POWERLIMIT_WATTS=100              # Recommended value for some GTX-1060: 76
+EQUIHASH_CORE_OVERCLOCK=0                # Recommended value for some GTX-1060: 150
+EQUIHASH_MEMORY_OVERCLOCK=0              # Recommended value for some GTX-1060: 400
 
 # Ethash
-ETHASH_POWERLIMIT_WATTS=100                # Recomended value for some GTX-1060: 76
-ETHASH_CORE_OVERCLOCK=0                  # Recomended value for some GTX-1060: 100
-ETHASH_MEMORY_OVERCLOCK=0                # Recomended value for some GTX-1060: 1600
+ETHASH_POWERLIMIT_WATTS=100                # Recommended value for some GTX-1060: 76
+ETHASH_CORE_OVERCLOCK=0                  # Recommended value for some GTX-1060: 100
+ETHASH_MEMORY_OVERCLOCK=0                # Recommended value for some GTX-1060: 1600
 
 # lyra2vRev2
-LYRA2REV2_POWERLIMIT_WATTS=100             # Recomended value for some GTX-1060: 65
-LYRA2REV2_CORE_OVERCLOCK=0               # Recomended value for some GTX-1060: 135
-LYRA2REV2_MEMORY_OVERCLOCK=0             # Recomended value for some GTX-1060: -1200
+LYRA2REV2_POWERLIMIT_WATTS=100             # Recommended value for some GTX-1060: 65
+LYRA2REV2_CORE_OVERCLOCK=0               # Recommended value for some GTX-1060: 135
+LYRA2REV2_MEMORY_OVERCLOCK=0             # Recommended value for some GTX-1060: -1200
 
 # lyra2v2
-LYRA2V2_POWERLIMIT_WATTS=100               # Recomended value for some GTX-1060: 65
-LYRA2V2_CORE_OVERCLOCK=0                 # Recomended value for some GTX-1060: 160
-LYRA2V2_MEMORY_OVERCLOCK=0               # Recomended value for some GTX-1060: -1000
+LYRA2V2_POWERLIMIT_WATTS=100               # Recommended value for some GTX-1060: 65
+LYRA2V2_CORE_OVERCLOCK=0                 # Recommended value for some GTX-1060: 160
+LYRA2V2_MEMORY_OVERCLOCK=0               # Recommended value for some GTX-1060: -1000
 
 # Neoscrypt
-NEOSCRYPT_POWERLIMIT_WATTS=100             # Recomended value for some GTX-1060: 80
-NEOSCRYPT_CORE_OVERCLOCK=0               # Recomended value for some GTX-1060: 150
-NEOSCRYPT_MEMORY_OVERCLOCK=0             # Recomended value for some GTX-1060: 800
+NEOSCRYPT_POWERLIMIT_WATTS=100             # Recommended value for some GTX-1060: 80
+NEOSCRYPT_CORE_OVERCLOCK=0               # Recommended value for some GTX-1060: 150
+NEOSCRYPT_MEMORY_OVERCLOCK=0             # Recommended value for some GTX-1060: 800
 
 # PHI1612
-PHI1612_POWERLIMIT_WATTS=100           # 
-PHI1612_CORE_OVERCLOCK=0               # 
-PHI1612_MEMORY_OVERCLOCK=0             # 
+PHI1612_POWERLIMIT_WATTS=100               # No recommended value available
+PHI1612_CORE_OVERCLOCK=0                 # No recommended value available
+PHI1612_MEMORY_OVERCLOCK=0               # No recommended value available
 
 # PHI2
-PHI2_POWERLIMIT_WATTS=100           # 
-PHI2_CORE_OVERCLOCK=0               # 
-PHI2_MEMORY_OVERCLOCK=0             # 
+PHI2_POWERLIMIT_WATTS=100                  # No recommended value available
+PHI2_CORE_OVERCLOCK=0                    # No recommended value available
+PHI2_MEMORY_OVERCLOCK=0                  # No recommended value available
 
 # Skunk
-SKUNK_POWERLIMIT_WATTS=100                 # Recomended value for some GTX-1060: 78
-SKUNK_CORE_OVERCLOCK=0                   # Recomended value for some GTX-1060: 150
-SKUNK_MEMORY_OVERCLOCK=0                 # Recomended value for some GTX-1060: 1000
+SKUNK_POWERLIMIT_WATTS=100                 # Recommended value for some GTX-1060: 78
+SKUNK_CORE_OVERCLOCK=0                   # Recommended value for some GTX-1060: 150
+SKUNK_MEMORY_OVERCLOCK=0                 # Recommended value for some GTX-1060: 1000
 
 # X16R
-X16R_POWERLIMIT_WATTS=100                  # Recomended value for some GTX-1060: 65
-X16R_CORE_OVERCLOCK=0                    # Recomended value for some GTX-1060: 100
-X16R_MEMORY_OVERCLOCK=0                  # Recomended value for some GTX-1060: 100
+X16R_POWERLIMIT_WATTS=100                  # Recommended value for some GTX-1060: 65
+X16R_CORE_OVERCLOCK=0                    # Recommended value for some GTX-1060: 100
+X16R_MEMORY_OVERCLOCK=0                  # Recommended value for some GTX-1060: 100
 
 # Xevan
-XEVAN_POWERLIMIT_WATTS=100                 # Recomended value for some GTX-1060: 65
-XEVAN_CORE_OVERCLOCK=0                   # Recomended value for some GTX-1060: 100
-XEVAN_MEMORY_OVERCLOCK=0                 # Recomended value for some GTX-1060: 600
+XEVAN_POWERLIMIT_WATTS=100                 # Recommended value for some GTX-1060: 65
+XEVAN_CORE_OVERCLOCK=0                   # Recommended value for some GTX-1060: 100
+XEVAN_MEMORY_OVERCLOCK=0                 # Recommended value for some GTX-1060: 600
 
 # ZHASH
-ZHASH_POWERLIMIT_WATTS=100           # 
-ZHASH_CORE_OVERCLOCK=150               # 
-ZHASH_MEMORY_OVERCLOCK=150             # 
+ZHASH_POWERLIMIT_WATTS=100                 # No recommended value available
+ZHASH_CORE_OVERCLOCK=150                 # No recommended value available
+ZHASH_MEMORY_OVERCLOCK=150               # No recommended value available
 
-daggerhashimoto_POWERLIMIT_WATTS=100       # Recomended value for some GTX-1060: 76
-daggerhashimoto_CORE_OVERCLOCK=0         # Recomended value for some GTX-1060: -200
-daggerhashimoto_MEMORY_OVERCLOCK=0       # Recomended value for some GTX-1060: 1200
+### IGNORE PL & OC SETTINGS BELOW THIS LINE IF YOU DON'T USE ANY SALFTER_* AUTO SWITCHER
 
-equihash_POWERLIMIT_WATTS=100              # Recomended value for some GTX-1060: 76
-equihash_CORE_OVERCLOCK=0                # Recomended value for some GTX-1060: 150
-equihash_MEMORY_OVERCLOCK=0              # Recomended value for some GTX-1060: 400
+# Nicehash and MiningPoolHub sometimes use different names fot the same algo. Therefore:
+#  - SALFTER_NICEHASH_SWITCHING matches Nicehash naming convention
+#  - SALFTER_MPH_SWITCHING matches MiningPoolHub naming convention
+#  - SALFTER_PROGRAMATIC_SWITCHING also matches MiningPoolHub convention
+# For your convenience, the matching naming convention is indicated above each settings block
 
-neoscrypt_POWERLIMIT_WATTS=100             # Recomended value for some GTX-1060: 80
-neoscrypt_CORE_OVERCLOCK=0               # Recomended value for some GTX-1060: 150
-neoscrypt_MEMORY_OVERCLOCK=0             # Recomended value for some GTX-1060: 800
+# daggerhashimoto @ NICEHASH
+daggerhashimoto_POWERLIMIT_WATTS=100       # Recommended value for some GTX-1060: 76
+daggerhashimoto_CORE_OVERCLOCK=0         # Recommended value for some GTX-1060: -200
+daggerhashimoto_MEMORY_OVERCLOCK=0       # Recommended value for some GTX-1060: 1200
 
-lyra2rev2_POWERLIMIT_WATTS=100             # Recomended value for some GTX-1060: 120
-lyra2rev2_CORE_OVERCLOCK=0               # Recomended value for some GTX-1060: 100
-lyra2rev2_MEMORY_OVERCLOCK=0             # Recomended value for some GTX-1060: 100
+# lbry @ NICEHASH
+lbry_POWERLIMIT_WATTS=100                  # Recommended value for some GTX-1060: 120
+lbry_CORE_OVERCLOCK=0                    # Recommended value for some GTX-1060: 100
+lbry_MEMORY_OVERCLOCK=0                  # Recommended value for some GTX-1060: 100
 
-lbry_POWERLIMIT_WATTS=100                  # Recomended value for some GTX-1060: 120
-lbry_CORE_OVERCLOCK=0                    # Recomended value for some GTX-1060: 100
-lbry_MEMORY_OVERCLOCK=0                  # Recomended value for some GTX-1060: 100
+# lyra2rev2 @ NICEHASH
+lyra2rev2_POWERLIMIT_WATTS=100             # Recommended value for some GTX-1060: 120
+lyra2rev2_CORE_OVERCLOCK=0               # Recommended value for some GTX-1060: 100
+lyra2rev2_MEMORY_OVERCLOCK=0             # Recommended value for some GTX-1060: 100
 
-blake_vanilla_POWERLIMIT_WATTS=100         # Recomended value for some GTX-1060: 120
-blake_vanilla_CORE_OVERCLOCK=0           # Recomended value for some GTX-1060: 100
-blake_vanilla_MEMORY_OVERCLOCK=100       # Recomended value for some GTX-1060: 100
+# equihash @ NICEHASH & MININGPOOLHUB
+equihash_POWERLIMIT_WATTS=100              # Recommended value for some GTX-1060: 76
+equihash_CORE_OVERCLOCK=0                # Recommended value for some GTX-1060: 150
+equihash_MEMORY_OVERCLOCK=0              # Recommended value for some GTX-1060: 400
 
-cryptonight_POWERLIMIT_WATTS=100           # Recomended value for some GTX-1060: 62
-cryptonight_CORE_OVERCLOCK=0             # Recomended value for some GTX-1060: 155
-cryptonight_MEMORY_OVERCLOCK=0           # Recomended value for some GTX-1060: -300
+# neoscrypt @ NICEHASH & MININGPOOLHUB
+neoscrypt_POWERLIMIT_WATTS=100             # Recommended value for some GTX-1060: 80
+neoscrypt_CORE_OVERCLOCK=0               # Recommended value for some GTX-1060: 150
+neoscrypt_MEMORY_OVERCLOCK=0             # Recommended value for some GTX-1060: 800
 
-cryptonight_monero_POWERLIMIT_WATTS=100    # Recomended value for some GTX-1060: 62
-cryptonight_monero_CORE_OVERCLOCK=0      # Recomended value for some GTX-1060: 155
-cryptonight_monero_MEMORY_OVERCLOCK=0    # Recomended value for some GTX-1060: -300
+# cryptonight_monero @ MININGPOOLHUB
+cryptonight_monero_POWERLIMIT_WATTS=100    # Recommended value for some GTX-1060: 62
+cryptonight_monero_CORE_OVERCLOCK=0      # Recommended value for some GTX-1060: 155
+cryptonight_monero_MEMORY_OVERCLOCK=0    # Recommended value for some GTX-1060: -300
 
-groestl_POWERLIMIT_WATTS=100               # Recomended value for some GTX-1060: 120
-groestl_CORE_OVERCLOCK=0                 # Recomended value for some GTX-1060: 100
-groestl_MEMORY_OVERCLOCK=0               # Recomended value for some GTX-1060: 100
+# ethash @ MININGPOOLHUB
+ethash_POWERLIMIT_WATTS=100                # Recommended value for some GTX-1060: 76
+ethash_CORE_OVERCLOCK=0                  # Recommended value for some GTX-1060: -200
+ethash_MEMORY_OVERCLOCK=0                # Recommended value for some GTX-1060: 1200
 
-keccak_POWERLIMIT_WATTS=100                # Recomended value for some GTX-1060: 120
-keccak_CORE_OVERCLOCK=0                  # Recomended value for some GTX-1060: 100
-keccak_MEMORY_OVERCLOCK=0                # Recomended value for some GTX-1060: 100
+# groestl @ MININGPOOLHUB
+groestl_POWERLIMIT_WATTS=100               # Recommended value for some GTX-1060: 120
+groestl_CORE_OVERCLOCK=0                 # Recommended value for some GTX-1060: 100
+groestl_MEMORY_OVERCLOCK=0               # Recommended value for some GTX-1060: 100
 
-myriad_groestl_POWERLIMIT_WATTS=100        # Recomended value for some GTX-1060: 120
-myriad_groestl_CORE_OVERCLOCK=0          # Recomended value for some GTX-1060: 100
-myriad_groestl_MEMORY_OVERCLOCK=0        # Recomended value for some GTX-1060: 100
+# keccak @ MININGPOOLHUB
+keccak_POWERLIMIT_WATTS=100                # Recommended value for some GTX-1060: 120
+keccak_CORE_OVERCLOCK=0                  # Recommended value for some GTX-1060: 100
+keccak_MEMORY_OVERCLOCK=0                # Recommended value for some GTX-1060: 100
 
-qubit_POWERLIMIT_WATTS=100                 # Recomended value for some GTX-1060: 120
-qubit_CORE_OVERCLOCK=0                   # Recomended value for some GTX-1060: 100
-qubit_MEMORY_OVERCLOCK=0                 # Recomended value for some GTX-1060: 100
+# lyra2re2 @ MININGPOOLHUB
+lyra2re2_POWERLIMIT_WATTS=100              # Recommended value for some GTX-1060: 120
+lyra2re2_CORE_OVERCLOCK=0                # Recommended value for some GTX-1060: 100
+lyra2re2_MEMORY_OVERCLOCK=0              # Recommended value for some GTX-1060: 100
 
-scrypt_POWERLIMIT_WATTS=100                # Recomended value for some GTX-1060: 120
-scrypt_CORE_OVERCLOCK=0                  # Recomended value for some GTX-1060: 100
-scrypt_MEMORY_OVERCLOCK=0                # Recomended value for some GTX-1060: 100
+# myriad_groestl @ MININGPOOLHUB
+myriad_groestl_POWERLIMIT_WATTS=100        # Recommended value for some GTX-1060: 120
+myriad_groestl_CORE_OVERCLOCK=0          # Recommended value for some GTX-1060: 100
+myriad_groestl_MEMORY_OVERCLOCK=0        # Recommended value for some GTX-1060: 100
 
-sia_POWERLIMIT_WATTS=100                   # Recomended value for some GTX-1060: 120
-sia_CORE_OVERCLOCK=0                     # Recomended value for some GTX-1060: 100
-sia_MEMORY_OVERCLOCK=0                   # Recomended value for some GTX-1060: 100
+# qubit @ MININGPOOLHUB
+qubit_POWERLIMIT_WATTS=100                 # Recommended value for some GTX-1060: 120
+qubit_CORE_OVERCLOCK=0                   # Recommended value for some GTX-1060: 100
+qubit_MEMORY_OVERCLOCK=0                 # Recommended value for some GTX-1060: 100
 
-skein_POWERLIMIT_WATTS=100                 # Recomended value for some GTX-1060: 120
-skein_CORE_OVERCLOCK=0                   # Recomended value for some GTX-1060: 100
-skein_MEMORY_OVERCLOCK=0                 # Recomended value for some GTX-1060: 100
+# scrypt @ MININGPOOLHUB
+scrypt_POWERLIMIT_WATTS=100                # Recommended value for some GTX-1060: 120
+scrypt_CORE_OVERCLOCK=0                  # Recommended value for some GTX-1060: 100
+scrypt_MEMORY_OVERCLOCK=0                # Recommended value for some GTX-1060: 100
 
-x11_POWERLIMIT_WATTS=100                   # Recomended value for some GTX-1060: 120
-x11_CORE_OVERCLOCK=0                     # Recomended value for some GTX-1060: 100
-x11_MEMORY_OVERCLOCK=0                   # Recomended value for some GTX-1060: 100
+# sia @ MININGPOOLHUB
+sia_POWERLIMIT_WATTS=100                   # Recommended value for some GTX-1060: 120
+sia_CORE_OVERCLOCK=0                     # Recommended value for some GTX-1060: 100
+sia_MEMORY_OVERCLOCK=0                   # Recommended value for some GTX-1060: 100
+
+# skein @ MININGPOOLHUB
+skein_POWERLIMIT_WATTS=100                 # Recommended value for some GTX-1060: 120
+skein_CORE_OVERCLOCK=0                   # Recommended value for some GTX-1060: 100
+skein_MEMORY_OVERCLOCK=0                 # Recommended value for some GTX-1060: 100
+
+# x11 @ MININGPOOLHUB
+x11_POWERLIMIT_WATTS=100                   # Recommended value for some GTX-1060: 120
+x11_CORE_OVERCLOCK=0                     # Recommended value for some GTX-1060: 100
+x11_MEMORY_OVERCLOCK=0                   # Recommended value for some GTX-1060: 100
 
 ################################################################
 #                                                              #

--- a/1bash.template
+++ b/1bash.template
@@ -166,11 +166,15 @@ AUTO_START_MINER="NO"      # YES or NO # Set this to NO when troubleshooting, th
 AUTO_SWITCH="NO"       # NO, WTM_SWITCHING, SALFTER_NICEHASH_SWITCHING,
                        # SALFTER_MPH_SWITCHING, SALFTER_PROGRAMATIC_SWITCHING
 
-#        - NO disables auto switching, mine previously selected COIN
-#        - WTM_SWTICHING whattomine.com switcher
-#        - SALFTER_NICEHASH_SWITCHING nicehash profit switcher
-#        - SALFTER_MPH_SWITCHING miningpoolhub profit switcher
-#        - SALFTER_PROGRAMATIC_SWITCHING reads the coin to switch to from a given URL
+# Notes: - NO disables auto switching, mine previously selected COIN
+#        - WTM_SWTICHING switch coin over your preferred pools following
+#          whattomine.com profitability charts
+#        - SALFTER_NICEHASH_SWITCHING switch algo over nicehash pools following
+#          nicehash profitabiliy charts
+#        - SALFTER_MPH_SWITCHING switch algo over miningpoolhub pools following
+#          miningpoolhub profitability charts
+#        - SALFTER_PROGRAMATIC_SWITCHING switch algo over pools provided by any
+#          custom api URL following its own profitability logic
 
 NUMBER_GPUS_INSTALLED=""    # Number or "" # Set number of GPUs installed. Watchdog will check installed vs detected. Leave empty to not check
 

--- a/3main
+++ b/3main
@@ -401,7 +401,10 @@ fi
 
 if [[ ${AUTO_SWITCH:0:7} == SALFTER ]]
 then
-  for a in daggerhashimoto equihash neoscrypt lyra2rev2 lbry blake_vanilla cryptonight cryptonight_monero groestl keccak myriad_groestl qubit scrypt sia skein x11
+  NICE_ALGO_NAMES="cryptonight cryptonightv7 daggerhashimoto lbry lyra2rev2"
+  MPH_ALGO_NAMES="cryptonight_monero ethash groestl lyra2re2 myriad_groestl skein"
+  SHARED_ALGO_NAMES="equihash keccak neoscrypt qubit scrypt sia x11"
+  for a in $NICE_ALGO_NAMES $MPH_ALGO_NAMES $SHARED_ALGO_NAMES
   do
     checkdef=${a}_POWERLIMIT_WATTS
     if [[ ${!checkdef} == "" ]]
@@ -545,12 +548,6 @@ then
   "min_profit": $MINIMUM_PROFIT,
   "miners":
   {
-    "Blake-Vanilla":
-    {
-      "bin": "${NVOC}/miners/SPccminer/ccminer -a vanilla -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x",
-      "power_limit": $pwr_lim_blake_vanilla, "gpu_oc": $gpu_clks_blake_vanilla, "mem_oc": $mem_clks_blake_vanilla, "fan": 0,
-      "speed": 12.3, "power": 0.389
-    },
     "Cryptonight-Monero":
     {
       "bin": "${NVOC}/miners/xmr-stak/xmr-stak_miner --currency monero7 --noCPU --noAMD -o {HOST}:{PORT} -u {NAME}.{MINER} -p x -i 0",
@@ -566,7 +563,7 @@ then
     "Ethash":
     {
       "bin": "${NVOC}/miners/ethminer/latest/ethminer -S {HOST}:{PORT} -O {NAME}.{MINER}:x -U",
-      "power_limit": $pwr_lim_daggerhashimoto, "gpu_oc": $gpu_clks_daggerhashimoto, "mem_oc": $mem_clks_daggerhashimoto, "fan": 0,
+      "power_limit": $pwr_lim_ethash, "gpu_oc": $gpu_clks_ethash, "mem_oc": $mem_clks_ethash, "fan": 0,
       "speed": 0.087, "power": 0.397
     },
     "Groestl":
@@ -584,7 +581,7 @@ then
     "Lyra2RE2":
     {
       "bin": "${NVOC}/miners//SPccminer/ccminer -a lyra2v2 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x",
-      "power_limit": $pwr_lim_lyra2rev2, "gpu_oc": $gpu_clks_lyra2rev2, "mem_oc": $mem_clks_lyra2rev2, "fan": 0,
+      "power_limit": $pwr_lim_lyra2re2, "gpu_oc": $gpu_clks_lyra2re2, "mem_oc": $mem_clks_lyra2re2, "fan": 0,
       "speed": 0.081, "power": 0.386
     },
     "Myriad-Groestl":
@@ -646,11 +643,6 @@ then
   "config_json_url": "$PROGRAMATIC_SWITCH_CONFIG_JSON_URL",
   "miners":
   {
-    "Blake-Vanilla":
-    {
-      "bin": "${NVOC}/miners/SPccminer/ccminer -a vanilla -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
-      "power_limit": $pwr_lim_blake_vanilla, "gpu_oc": $gpu_clks_blake_vanilla, "mem_oc": $mem_clks_blake_vanilla, "fan": 0
-    },
     "Cryptonight":
     {
       "bin": "${NVOC}/miners/KTccminer-cryptonight/ccminer -o stratum+tcp://{HOST}:{PORT} -u {NAME} -p x",
@@ -674,7 +666,7 @@ then
     "Ethash":
     {
       "bin": "${NVOC}/miners/ethminer/latest/ethminer -S {HOST}:{PORT} -O {NAME}.{MINER}:x -U",
-      "power_limit": $pwr_lim_daggerhashimoto, "gpu_oc": $gpu_clks_daggerhashimoto, "mem_oc": $mem_clks_daggerhashimoto, "fan": 0
+      "power_limit": $pwr_lim_ethash, "gpu_oc": $gpu_clks_ethash, "mem_oc": $mem_clks_ethash, "fan": 0
     },
     "Groestl":
     {
@@ -689,7 +681,7 @@ then
     "Lyra2RE2":
     {
       "bin": "${NVOC}/miners/SPccminer/ccminer -a lyra2v2 -o stratum+tcp://{HOST}:{PORT} -u {NAME}.{MINER} -p x -p c={COIN_CURRENCY}",
-      "power_limit": $pwr_lim_lyra2rev2, "gpu_oc": $gpu_clks_lyra2rev2, "mem_oc": $mem_clks_lyra2rev2, "fan": 0
+      "power_limit": $pwr_lim_lyra2re2, "gpu_oc": $gpu_clks_lyra2re2, "mem_oc": $mem_clks_lyra2re2, "fan": 0
     },
     "Myriad-Groestl":
     {

--- a/3main
+++ b/3main
@@ -403,11 +403,46 @@ if [[ ${AUTO_SWITCH:0:7} == SALFTER ]]
 then
   for a in daggerhashimoto equihash neoscrypt lyra2rev2 lbry blake_vanilla cryptonight cryptonight_monero groestl keccak myriad_groestl qubit scrypt sia skein x11
   do
-    if [[ $OVERCLOCK_MODE == NO ]]
+    checkdef=${a}_POWERLIMIT_WATTS
+    if [[ ${!checkdef} == "" ]]
     then
-      eval gpu_clks_$a=0
-      eval mem_clks_$a=0
-    elif [[ $OVERCLOCK_MODE == GLOBAL ]]
+      eval ${a}_POWERLIMIT_WATTS=$_POWERLIMIT_WATTS
+    fi
+
+    if [[ $POWERLIMIT_MODE == GLOBAL_with_GPU_OFFSET ]]
+    then
+      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((_POWERLIMIT_WATTS+INDIVIDUAL_POWERLIMIT_/' -e 's/$/))/' | paste -s -d, -)]"
+    elif [[ $POWERLIMIT_MODE == GPU_SPECIFIC ]]
+    then
+      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\${INDIVIDUAL_POWERLIMIT_/' -e 's/$/}/' | paste -s -d, -)]"
+    elif [[ $POWERLIMIT_MODE == ALGO_SPECIFIC ]]
+    then
+      eval pwr_lim_$a=$((${a}_POWERLIMIT_WATTS))
+    elif [[ $POWERLIMIT_MODE == ALGO_SPECIFIC_with_GPU_OFFSET ]]
+    then
+      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((${a}_POWERLIMIT_WATTS+INDIVIDUAL_POWERLIMIT_/' -e 's/$/))/' | paste -s -d, -)]"
+    else
+      if [[ $POWERLIMIT_MODE != GLOBAL ]]
+      then
+          echo "WARNING: '$POWERLIMIT_MODE' is not a valid powerlimit mode, falling back to 'GLOBAL'"
+      fi
+      eval pwr_lim_$a=$_POWERLIMIT_WATTS
+    fi
+    POWERLIMIT_MODE="MANAGED_BY_SWITCHER"
+
+    checkdef=${a}_CORE_OVERCLOCK
+    if [[ ${!checkdef} == "" ]]
+    then
+      eval ${a}_CORE_OVERCLOCK=$_CORE_OVERCLOCK
+    fi
+
+    checkdef=${a}_MEMORY_OVERCLOCK
+    if [[ ${!checkdef} == "" ]]
+    then
+      eval ${a}_MEMORY_OVERCLOCK=$_MEMORY_OVERCLOCK
+    fi
+    
+    if [[ $OVERCLOCK_MODE == GLOBAL ]]
     then
       eval gpu_clks_$a=$_CORE_OVERCLOCK
       eval mem_clks_$a=$_MEMORY_OVERCLOCK
@@ -427,26 +462,15 @@ then
     then
       eval gpu_clks_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((${a}_CORE_OVERCLOCK + __CORE_OVERCLOCK_/' -e 's/$/))/' | paste -s -d, -)]"
       eval mem_clks_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((${a}_MEMORY_OVERCLOCK + MEMORY_OVERCLOCK_/' -e 's/$/))/' | paste -s -d, -)]"
+    else
+      if [[ $OVERCLOCK_MODE != NO ]]
+      then
+        echo "WARNING: '$OVERCLOCK_MODE' is not a valid overclock mode, falling back to 'NO'"
+      fi
+      eval gpu_clks_$a=0
+      eval mem_clks_$a=0
     fi
     OVERCLOCK_MODE="MANAGED_BY_SWITCHER"
-
-    if [[ $POWERLIMIT_MODE == GLOBAL ]]
-    then
-      eval pwr_lim_$a=$_POWERLIMIT_WATTS
-    elif [[ $POWERLIMIT_MODE == GLOBAL_with_GPU_OFFSET ]]
-    then
-      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((_POWERLIMIT_WATTS+INDIVIDUAL_POWERLIMIT_/' -e 's/$/))/' | paste -s -d, -)]"
-    elif [[ $POWERLIMIT_MODE == GPU_SPECIFIC ]]
-    then
-      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\${INDIVIDUAL_POWERLIMIT_/' -e 's/$/}/' | paste -s -d, -)]"
-    elif [[ $POWERLIMIT_MODE == ALGO_SPECIFIC ]]
-    then
-      eval pwr_lim_$a=$((${a}_POWERLIMIT_WATTS))
-    elif [[ $POWERLIMIT_MODE == ALGO_SPECIFIC_with_GPU_OFFSET ]]
-    then
-      eval pwr_lim_$a="[$(seq 0 $((GPUS-1)) | sed -e 's/^/\$((${a}_POWERLIMIT_WATTS+INDIVIDUAL_POWERLIMIT_/' -e 's/$/))/' | paste -s -d, -)]"
-    fi
-    POWERLIMIT_MODE="MANAGED_BY_SWITCHER"
   done
 fi
 
@@ -751,6 +775,8 @@ fi
 
 source ${NVOC}/0algo_id
 
+UNDEFINED_POWERLIMIT_WATTS=$_POWERLIMIT_WATTS
+
 if [[ $POWERLIMIT_MODE == GLOBAL ]]
 then
   sudo nvidia-smi -pl "$_POWERLIMIT_WATTS"
@@ -803,14 +829,10 @@ else
   pkill -f OhGodAnETHlargementPill-r2
 fi
 
-if [[ $OVERCLOCK_MODE == NO ]]
-then
-  for i in $(seq 0 $((GPUS-1)))
-  do
-    __CORE_OVERCLOCK[$i]=0
-    MEMORY_OVERCLOCK[$i]=0
-  done
-elif [[ $OVERCLOCK_MODE == GLOBAL ]]
+UNDEFINED_CORE_OVERCLOCK=$_CORE_OVERCLOCK
+UNDEFINED_MEMORY_OVERCLOCK=$_MEMORY_OVERCLOCK
+
+if [[ $OVERCLOCK_MODE == GLOBAL ]]
 then
   for i in $(seq 0 $((GPUS-1)))
   do
@@ -831,29 +853,34 @@ then
     __CORE_OVERCLOCK[$i]=$((__CORE_OVERCLOCK_$i))
     MEMORY_OVERCLOCK[$i]=$((MEMORY_OVERCLOCK_$i))
   done
+elif [[ $OVERCLOCK_MODE == ALGO_SPECIFIC_with_GPU_OFFSET ]]
+then
+  for i in $(seq 0 $((GPUS-1)))
+  do
+    __CORE_OVERCLOCK[$i]=$(( ${ALGO}_CORE_OVERCLOCK + __CORE_OVERCLOCK_$i ))
+    MEMORY_OVERCLOCK[$i]=$(( ${ALGO}_MEMORY_OVERCLOCK + MEMORY_OVERCLOCK_$i ))
+  done
+elif [[ $OVERCLOCK_MODE == ALGO_SPECIFIC ]]
+then
+  for i in $(seq 0 $((GPUS-1)))
+  do
+    __CORE_OVERCLOCK[$i]=$((${ALGO}_CORE_OVERCLOCK))
+    MEMORY_OVERCLOCK[$i]=$((${ALGO}_MEMORY_OVERCLOCK))
+  done
 elif [[ $OVERCLOCK_MODE == MANAGED_BY_SWITCHER ]]
 then
   echo "INFO: An auto-switcher is taking over GPU Core and Memory clocks management."
   echo
 else
-  UNDEFINED_CORE_OVERCLOCK=$_CORE_OVERCLOCK
-  UNDEFINED_MEMORY_OVERCLOCK=$_MEMORY_OVERCLOCK
-
-  if [[ $OVERCLOCK_MODE == ALGO_SPECIFIC_with_GPU_OFFSET ]]
+  if [[ $OVERCLOCK_MODE != NO ]]
   then
-    for i in $(seq 0 $((GPUS-1)))
-    do
-      __CORE_OVERCLOCK[$i]=$(( ${ALGO}_CORE_OVERCLOCK + __CORE_OVERCLOCK_$i ))
-      MEMORY_OVERCLOCK[$i]=$(( ${ALGO}_MEMORY_OVERCLOCK + MEMORY_OVERCLOCK_$i ))
-    done
-  elif [[ $OVERCLOCK_MODE == ALGO_SPECIFIC ]]
-  then
-    for i in $(seq 0 $((GPUS-1)))
-    do
-      __CORE_OVERCLOCK[$i]=$((${ALGO}_CORE_OVERCLOCK))
-      MEMORY_OVERCLOCK[$i]=$((${ALGO}_MEMORY_OVERCLOCK))
-    done
+    echo "WARNING: '$OVERCLOCK_MODE' is not a valid overclock mode, falling back to 'NO'"
   fi
+  for i in $(seq 0 $((GPUS-1)))
+  do
+    __CORE_OVERCLOCK[$i]=0
+    MEMORY_OVERCLOCK[$i]=0
+  done
 fi
 
 if [[ $SLOW_USB_KEY_MODE == YES ]]

--- a/3main
+++ b/3main
@@ -428,7 +428,7 @@ then
       fi
       eval pwr_lim_$a=$_POWERLIMIT_WATTS
     fi
-    POWERLIMIT_MODE="MANAGED_BY_SWITCHER"
+    
 
     checkdef=${a}_CORE_OVERCLOCK
     if [[ ${!checkdef} == "" ]]
@@ -470,8 +470,10 @@ then
       eval gpu_clks_$a=0
       eval mem_clks_$a=0
     fi
-    OVERCLOCK_MODE="MANAGED_BY_SWITCHER"
   done
+  
+  POWERLIMIT_MODE="MANAGED_BY_SWITCHER"
+  OVERCLOCK_MODE="MANAGED_BY_SWITCHER"
 fi
 
 if [[ $AUTO_SWITCH == SALFTER_NICEHASH_SWITCHING ]]


### PR DESCRIPTION
- Now all oc policies fallbacks for salfter-based switchers are the same for wtm and single coin settings
- Fallback values fo undefined or missing algo-specific settings are now silently applied also for salfter-based switchers
- Prints a warning every time a policy is invalid and a fallback policy applies
- Addresses an issue which prevented algos different from daggerhashimoto in salfter-based switchers to get correct oc & pl settings (Fixes #161)