### PR TITLE
Allow different cryptonight ccminer's

### DIFF
--- a/0miner
+++ b/0miner
@@ -223,8 +223,15 @@ then
 ## CRYPTONIGHT
 elif [[ $ALGO == CRYPTONIGHT ]]
 then
-  HCD="${NVOC}"/miners/KTccminer-cryptonight/ccminer
-  eval $LAUNCH $HCD -o ${!xproto}://"${!xpool}":"${!xport}" -u "${!xaddr}""${!xwallet}""${!xwork}" -p "$MINER_PWD" -i "${!xintensity}" $CCMINER_OPTS ${!xext}
+  if [[ $CRYPTONIGHT_MINER == KTccminer-cryptonight ]]
+  then
+    HCD="${NVOC}"/miners/"${!xminer}"/ccminer
+    eval $LAUNCH $HCD -o ${!xproto}://"${!xpool}":"${!xport}" -u "${!xaddr}""${!xwallet}""${!xwork}" -p "$MINER_PWD" $CCMINER_OPTS ${!xext}
+  else
+    UCCALGO="-a ${ALGO,,}"
+    HCD="${NVOC}"/miners/"${!xminer}"/ccminer
+    eval $LAUNCH $HCD $UCCALGO -o ${!xproto}://"${!xpool}":"${!xport}" -u "${!xaddr}""${!xwallet}""${!xwork}" -p "$MINER_PWD" -i "${!xintensity}" $CCMINER_OPTS ${!xext}
+  fi
 
 ## PASCAL
 elif [[ $ALGO == PASCAL ]]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Version: always the latest, from configurable branch (default: [release](https:/
 | host | size   | download                                                                       |
 |------|--------|--------------------------------------------------------------------------------|
 | MEGA | 3,50GB | [link](https://mega.nz/#!od1HGYjZ!kMp4ihj2TK81hNz6GkBR1--UkPhNf-JmdGHHEeDw3Ig) |
+| GDrive | 3,50GB | [link](https://drive.google.com/folderview?id=1B0G83ZQm6a7-5irzBSo7YrYyk353HtIg) |
 
 Checksums:
 
@@ -60,7 +61,7 @@ Version: beta testing snapshot branch [19-2.1@a3e92bd976997327fc971b549066f8a566
 
 | host | size   | download                                                                       |
 |------|--------|--------------------------------------------------------------------------------|
-| MEGA | 3,43GB | [link](https://mega.nz/#!dNVTBIAC!7GGJpn9F-kehJOd1gW60CcR28BHTR3WMJxS7K-hd6Tg) |
+| MEGA | 3,43GB | deprecated, get newer versions |
 
 Checksums:
 


### PR DESCRIPTION
- Removed invalid "-i" option for intensity into KTccminer-cryptonight command line
- Add support for other ccminer's when selected miners is not KTccminer-cryptonight

_Note: this is just a workaround to allow current builtin miners that supports the old cryptonight variant to be somehow selected for mining that algo. I'm reluctant in spending more effort for a decent miner selection for this old algo since it is quite old and this issue will be implicitly addressed when we switch to pluggable miners._
