### PR TITLE
Add default resolution var for teamviewer usage

### DIFF
--- a/1bash.template
+++ b/1bash.template
@@ -187,6 +187,7 @@ LOCALorREMOTE="LOCAL"       # LOCAL or REMOTE # Set to LOCAL if you have local a
 
 
 TEAMVIEWER="NO"             # YES or NO # If you use Team Viewer to remotely connect to this rig set this to YES
+RESOLUTION="1366x768"
 
 SSH="YES"                   # YES or NO # If you use SSH to remotely connect to this rig set this to YES
 

--- a/1bash.template
+++ b/1bash.template
@@ -330,6 +330,8 @@ INDIVIDUAL_TARGET_TEMPS="NO"  # YES or NO, if YES global target temperature is o
 
 TARGET_TEMP=65                # Set the desired global (all GPU's) target temperature in Celsius. Recommended ranges: 55 - 75
 
+SHUTDOWN_TEMP=90	      # Forcefully shutdown the system if any GPU exceeds this temperature in Celsius. Recommended: 80+
+
 ALLOWED_TEMP_DIFF=2           # If current temp is 2C below the target temp reduce the fan speed. Works only if current temp is below target temp
 
 MINIMAL_FAN_SPEED=50          # Lowest fan speed that will be used. Recommended ranges: 40 - 60

--- a/1bash.template
+++ b/1bash.template
@@ -187,7 +187,7 @@ LOCALorREMOTE="LOCAL"       # LOCAL or REMOTE # Set to LOCAL if you have local a
 
 
 TEAMVIEWER="NO"             # YES or NO # If you use Team Viewer to remotely connect to this rig set this to YES
-RESOLUTION="1366x768"
+RESOLUTION="1366x768"       # Default system resolution used when connecting through TeamViewer
 
 SSH="YES"                   # YES or NO # If you use SSH to remotely connect to this rig set this to YES
 

--- a/1bash.template
+++ b/1bash.template
@@ -113,10 +113,11 @@ v0034="LuKePicci;Rearrange settings and explaination comments"
 v0035="LuKePicci;Uniform plusCPU handling"
 v0036="papampi;Ethminer new arguments, Coin Pool Protocol"
 v0037="papampi;Added bminer scheme info for zhash & tensority based coins"
+v0038="Spiral;Added max temperature shutdown option & resolution option for teamviewer
 
 # Do not edit these lines
 nvOC_Ver="v0019-2.1" 
-nvOC_1bash_ver="0037"
+nvOC_1bash_ver="0038"
 nvOC_1bash_least_compatible="0034"
 nvOC_1bash_last_compatible="0035"
 

--- a/1bash.template
+++ b/1bash.template
@@ -330,7 +330,8 @@ INDIVIDUAL_TARGET_TEMPS="NO"  # YES or NO, if YES global target temperature is o
 
 TARGET_TEMP=65                # Set the desired global (all GPU's) target temperature in Celsius. Recommended ranges: 55 - 75
 
-SHUTDOWN_TEMP=90	      # Forcefully shutdown the system if any GPU exceeds this temperature in Celsius. Recommended: 80+
+HOT_SHUTDOWN="YES"	      # YES or NO, if YES system will shutdown when SHUTDOWN_TEMP is exceeded.
+SHUTDOWN_TEMP=85	      # If HOT_SHUTDOWN is YES then the system will shutdown if this number is exceeded. (Celsius)
 
 ALLOWED_TEMP_DIFF=2           # If current temp is 2C below the target temp reduce the fan speed. Works only if current temp is below target temp
 

--- a/3main
+++ b/3main
@@ -105,9 +105,12 @@ then
     sleep 2
     guake -n teamviewer -r teamviewer -e "teamviewer" &
     running=""
-    echo "Setting Resolution to $RESOLUTION"
-    xrandr --fb $RESOLUTION
-    echo "" 
+    if [[ $RESOLUTION != "" ]]
+    then
+      echo "Setting resolution to $RESOLUTION"
+      xrandr --fb $RESOLUTION
+      echo "" 
+    fi
   fi  
 fi
 

--- a/3main
+++ b/3main
@@ -70,6 +70,8 @@
 #          Support CUDA version selection
 # v=0025 : LuKePicci
 #          Support pluggable miners
+# v=0026 : Spiral
+#	   Set resolution from 1bash for teamviewer usage
 
 source ${NVOC}/1bash
 

--- a/3main
+++ b/3main
@@ -103,7 +103,10 @@ then
     sleep 2
     guake -n teamviewer -r teamviewer -e "teamviewer" &
     running=""
-  fi
+    echo "Setting Resolution to $RESOLUTION"
+    xrandr --fb $RESOLUTION
+    echo "" 
+  fi  
 fi
 
 if [[ $TEAMVIEWER == NO ]]

--- a/3main
+++ b/3main
@@ -75,7 +75,7 @@
 
 source ${NVOC}/1bash
 
-nvOC_3main_Dev="0025"
+nvOC_3main_Dev="0026"
 nvOC_3main_ver="$nvOC_ver.$nvOC_3main_Dev"             # Do not edit this
 
 #########################################################################

--- a/6tempcontrol
+++ b/6tempcontrol
@@ -35,11 +35,13 @@
 #          Use sysrq reboot, to prevent freeze/hang
 # v=0007 : LuKePicci
 #          Reduce calls to nvidia-smi and nvidia-settings 
+# v=0008 : Spiral
+#          Add loop to shutdown rig if SHUTDOWN_TEMP exceeded
 
 source ${NVOC}/1bash
 source ${NVOC}/helpers/coin_algo_mapping
 
-nvOC_temp_Dev="0007"
+nvOC_temp_Dev="0008"
 nvOC_temp_ver="$nvOC_Ver.$nvOC_temp_Dev"   # Do not edit this
 
 export DISPLAY=:0

--- a/6tempcontrol
+++ b/6tempcontrol
@@ -223,7 +223,7 @@ do
     # Numeric check to avoid script breakage should nvidia-smi return error, also acts as backup watchdog
 
     #Shutdown rig if SHUTDOWN_TEMP reached
-    if [[ $CURRENT_TEMP -gt $SHUTDOWN_TEMP ]]
+    if [[ $CURRENT_TEMP -gt $SHUTDOWN_TEMP ]] && [[ $HOT_SHUTDOWN == "YES" ]]
     then
 	if [[ $TELEGRAM_ALERTS == "YES" ]] || [[ $TELEGRAM_MESSAGES == "YES" ]]
         then

--- a/6tempcontrol
+++ b/6tempcontrol
@@ -222,6 +222,17 @@ do
 
     # Numeric check to avoid script breakage should nvidia-smi return error, also acts as backup watchdog
 
+    #Shutdown rig if SHUTDOWN_TEMP reached
+    if [[ $CURRENT_TEMP -gt $SHUTDOWN_TEMP ]]
+	  then
+	      if [[ $TELEGRAM_ALERTS == "YES" ]] || [[ $TELEGRAM_MESSAGES == "YES" ]]
+        then
+          /usr/bin/curl -m 5 -s -X POST --output /dev/null https://api.telegram.org/bot$TELEGRAM_APIKEY/sendMessage -d "text=GPU$GPU exceeded $SHUTDOWN_TEMP c. System shutting down." -d chat_id=$TELEGRAM_CHATID
+        fi
+        sleep 2
+        sudo poweroff -f      
+    fi
+
     # Workaround for 1050's reporting "[Not Supported]" or "[Unknown Error]" when power.draw is queried from nvidia-smi
     if [[ $GPU_NAME =~ 1050 ]]
     then

--- a/6tempcontrol
+++ b/6tempcontrol
@@ -224,8 +224,8 @@ do
 
     #Shutdown rig if SHUTDOWN_TEMP reached
     if [[ $CURRENT_TEMP -gt $SHUTDOWN_TEMP ]]
-	  then
-	      if [[ $TELEGRAM_ALERTS == "YES" ]] || [[ $TELEGRAM_MESSAGES == "YES" ]]
+    then
+	if [[ $TELEGRAM_ALERTS == "YES" ]] || [[ $TELEGRAM_MESSAGES == "YES" ]]
         then
           /usr/bin/curl -m 5 -s -X POST --output /dev/null https://api.telegram.org/bot$TELEGRAM_APIKEY/sendMessage -d "text=GPU$GPU exceeded $SHUTDOWN_TEMP c. System shutting down." -d chat_id=$TELEGRAM_CHATID
         fi


### PR DESCRIPTION
By default connecting via teamviewer uses 800x600, this lets the user specify system resolution in 1bash which is then set if teamviewer is enabled in 3main.