### PR TITLE
Removing old miners and adding CCMINER_OPTS usage

### DIFF
--- a/0miner
+++ b/0miner
@@ -124,7 +124,7 @@ OPTS="${!xcoinopts} $(dgh_get_miner_opts "${!xminer}" "$COIN" "$ALGO")"
 mpath="${NVOC}/miners/${!xminer}"
 
 # List of cuda-8.0 miners
-CUDA_8_MINERS="ANXccminer ASccminer KXccminer MSFTccminer NAccminer SILENTminer SPccminer SUPRminer VERTMINER"
+CUDA_8_MINERS=""
 LAUNCH="screen -c ${NVOC}/screenrc-miner -dmSL miner"
 for miner in $CUDA_8_MINERS
 do
@@ -190,11 +190,11 @@ then
   pm_manifest=${mpath}/${!xversion}/nvoc-miner.json
   
   # parse device enable params
-  dev_enable_arg="$(jq -r .devlist_argument ${pm_manifest})"
+  dev_enable_arg=$(eval $(jq -r .devlist_argument ${pm_manifest}))
   if [[ $dev_enable_arg != "" ]]
   then
-    dev_enable_sep="$(jq -r .devlist_separator ${pm_manifest})"
-    dev_enable_fmt="$(jq -r .devlist_format ${pm_manifest})"
+    dev_enable_sep=$(eval $(jq -r .devlist_separator ${pm_manifest}))
+    dev_enable_fmt=$(eval $(jq -r .devlist_format ${pm_manifest}))
     OPTS="$(dgh_enabled_devices '${dev_enable_arg}' '${dev_enable_sep}' '${dev_enable_fmt}' "$OPTS")"
   fi
 
@@ -260,7 +260,7 @@ then
   OPTS="$(dgh_enabled_devices '--devices ' ',' 'N' "$OPTS")"
   UCCALGO="-a ${ALGO,,}"
   HCD="${NVOC}"/miners/"${!xminer}"/"${!xversion}"/ccminer
-  eval $LAUNCH $HCD $UCCALGO -o ${!xproto}://"${!xpool}":"${!xport}" -u "${!xaddr}""${!xwallet}""${!xwork}" -p "$MINER_PWD" -i "${!xintensity}" $OPTS
+  eval $LAUNCH $HCD $UCCALGO -o ${!xproto}://"${!xpool}":"${!xport}" -u "${!xaddr}""${!xwallet}""${!xwork}" -p "$MINER_PWD" -i "${!xintensity}" $OPTS $CCMINER_OPTS
 
 
 ## CRYPTONIGHT

--- a/1bash.template
+++ b/1bash.template
@@ -717,7 +717,7 @@ EWBF_VERSION="recommended"                         # "latest", "recommended" or 
 GMINER_OPTS=""
 GMINER_VERSION="recommended"                     # "latest", "recommended" or the version folder name.
 
-LOLMINER_OPTS="-apiport=9999"                      # LOLMINER optional arguments.
+LOLMINER_OPTS=""                                   # LOLMINER optional arguments.
 LOLMINER_VERSION="recommended"                     # "latest", "recommended" or the version folder name.
 
 PhoenixMiner_OPTS="-cdm 1 -cdmport 127.0.0.1:3333" # PhoenixMiner optional arguments. Read the README file inside PhoenixMiner folder

--- a/1bash.template
+++ b/1bash.template
@@ -495,9 +495,7 @@ MINER_PWD="x"                                    # Set the miner password. Defau
 
 # Available builtin miners:
 #        Various algos:
-#          "ANXccminer", "ASccminer", "CryptoDredge", "KTccminer",  
-#          "KXccminer", "SILENTminer", "SPccminer",  "SUPRminer",   
-#          "TPccminer", "T_Rex", "VERTMINER", "XMR_Stak", "ZENEMYminer"
+#          "CryptoDredge", "TPccminer", "T_Rex", "XMR_Stak", "ZENEMYminer"
 #        Energi:
 #          "ENERGIMINER"
 #        Equihash:
@@ -567,7 +565,7 @@ KECCAK_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## LBRY
 LBRY_INTENSITY="0"
-LBRY_MINER="SPccminer"
+LBRY_MINER="TPccminer"
 LBRY_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## LYRA2REV2
@@ -602,7 +600,7 @@ PASCAL_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## PHI1612
 PHI1612_INTENSITY="0"
-PHI1612_MINER="ANXccminer"
+PHI1612_MINER="CryptoDredge"
 PHI1612_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## PHI2
@@ -612,7 +610,7 @@ PHI2_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## SIA
 SIA_INTENSITY="0"
-SIA_MINER="SPccminer"
+SIA_MINER="TPccminer"
 SIA_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## SKEIN
@@ -627,7 +625,7 @@ SKUNK_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## X11GHOST, SIB
 X11GHOST_INTENSITY="0"
-X11GHOST_MINER="SPccminer"
+X11GHOST_MINER="TPccminer"
 X11GHOST_WALLET_FORMAT="$WALLET_ADDRESS_FORMAT"
 
 ## X13
@@ -703,7 +701,7 @@ CLAYMORE_VERSION="recommended"                     # "latest", "recommended" or 
 CryptoDredge_OPTS=""                                   # CryptoDredge optional arguments
 CryptoDredge_VERSION="recommended"                     # "latest", "recommended" or the version folder name.
 
-DSTM_OPTS="--telemetry=127.0.0.1:2222"             # DSTM Miner optional arguments add "--telemetry=$IPW:42000" if you want web info
+DSTM_OPTS=""                                       # DSTM Miner optional arguments add "--telemetry=$IPW:42000" if you want web info
 DSTM_VERSION="recommended"                         # "latest", "recommended" or the version folder name.
 
 ENERGIMINER_OPTS="--response-timeout 10 --cuda-parallel-hash 8 --cuda-block-size 256"    # ENERGIMINER Miner optional arguments
@@ -735,8 +733,8 @@ Z_EWBF_VERSION="recommended"                       # "latest", "recommended" or 
 ZENEMYminer_OPTS=""
 ZENEMYminer_VERSION="recommended"                  # "latest", "recommended" or the version folder name.
 
-CCMINER_OPTS="-b 127.0.0.1:4028"                   # ccminer optional arguments. Add "-b 0.0.0.0:4028", or "-b $IPW:42000" if you want 
-                                                   # web info (first one allows remote monitoring by default)
+CCMINER_OPTS="-b 127.0.0.1:4068"                   # ccminer optional arguments. Add "-b 0.0.0.0:4068" if you want 
+                                                   # web info
 
 ########################################################
 #                                                      #

--- a/foreman/miner-watch
+++ b/foreman/miner-watch
@@ -40,81 +40,12 @@ check_miner() {
         # Attempt to parse the command line for the information.  This should all be removed
         # once everything is migrated to the new pluggable miner design
         case $MINER in
-            "anxccminer")
-                MINER="ccminer-phi"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "asccminer")
-                MINER="ccminer-alexis78"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "bminer")
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "api 127.0.0.1:[0-9]{4,5}" | cut -d '=' -f2 | cut -d ':' -f2 | xargs)
-                ;;
-            "claymore")
-                MINER="claymore-eth"
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "mport [0-9]{4,5}" | cut -d ' ' -f2 | xargs)
-                ;;
-            "cryptodredge")
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "dstm")
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "telemetry=127.0.0.1:[0-9]{4,5}" | cut -d '=' -f2 | cut -d ':' -f2 | xargs)
-                ;;
-            "ewbf")
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "api 127.0.0.1:[0-9]{4,5}" | cut -d '=' -f2 | cut -d ':' -f2 | xargs)
-                ;;
-            "ktccminer")
-                MINER="ccminer-klaust"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "kxccminer")
-                MINER="ccminer-xevan"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "lolminer")
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "apiport=[0-9]{4,5}" | cut -d '=' -f2 | xargs)
-                ;;
-            "msftccminer")
-                MINER="ccminer-msft"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "naccminer")
-                MINER="ccminer-nanashi"
-                API_PORT=$(get_ccminer_port)
-                ;;
             "phoenixminer")
                 MINER="phoenix"
                 API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "cdmport [0-9]{4,5}" | cut -d ' ' -f2 | xargs)
                 ;;
-            "silentminer")
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "sp_suprminer")
-                MINER="suprminer-sp-hash"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "spccminer")
-                MINER="ccminer-sp-hash"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "suprminer")
-                API_PORT=$(get_ccminer_port)
-                ;;
             "tpccminer")
                 MINER="ccminer-tpruvot"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "t_rex")
-                MINER="trex"
-                API_PORT=$(pgrep -afn "$MINERS" | grep -Eo "api-bind-http 127.0.0.1:[0-9]{4,5}" | cut -d ' ' -f2 | cut -d ':' -f2 | xargs)
-                ;;
-            "vertminer")
-                MINER="vertminer-nvidia"
-                API_PORT=$(get_ccminer_port)
-                ;;
-            "zenemyminer")
-                MINER="z-enemy"
                 API_PORT=$(get_ccminer_port)
                 ;;
             *)


### PR DESCRIPTION
Removing cuda 8 miners and fixing a few things that I found while testing.  Not entirely sure about the eval in 0miner that's wrapping the jq call.  I basically reverted that back to what it was before the $(eval got nuked and things started working again.

**Can somebody please** go through 3main and remove the usage of the miners that I nuked?  I think that all SPccminer usages can safely be replaced with TPccminer.  I didn't touch anything there because I'm unable to test NiceHash or autoswitching (don't use them).