### PR TITLE
Add missing Modelines for default resolutions

### DIFF
--- a/1bash.template
+++ b/1bash.template
@@ -232,7 +232,7 @@ LOCALorREMOTE="LOCAL"       # LOCAL or REMOTE # Set to LOCAL if you have local a
 
 TEAMVIEWER="NO"             # YES or NO # If you use Team Viewer to remotely connect to this rig set this to YES
 
-RESOLUTION="1366x768"       # Default system resolution used when connecting through TeamViewer
+RESOLUTION="1366x768"       # 1366x768 or 1280x1024 # Default system resolution used whenconnecting through TeamViewer or VNC
 
 
 SSH="YES"                   # YES or NO # If you use SSH to remotely connect to this rig set this to YES

--- a/3main
+++ b/3main
@@ -118,13 +118,14 @@ then
     guake -n teamviewer -r teamviewer -e "teamviewer" &
     sleep 1
     running=""
-    if [[ $RESOLUTION != "" ]]
-    then
-      echo "Setting resolution to $RESOLUTION"
-      xrandr --fb $RESOLUTION
-      echo "" 
-    fi
   fi  
+fi
+
+if [[ $RESOLUTION != "" ]]
+then
+  echo "Setting resolution to $RESOLUTION"
+  xrandr --fb $RESOLUTION
+  echo "" 
 fi
 
 if [[ $SRR == YES ]]

--- a/xorg.conf.default
+++ b/xorg.conf.default
@@ -52,6 +52,9 @@ Section "Monitor"
     ModelName      "CLB  fit Headless"
     HorizSync       30.0 - 83.0
     VertRefresh     56.0 - 76.0
+    Modeline       "1280x1024_25.00"   41.50  1280 1320 1440 1600  1024 1027 1034 1042 -hsync +vsync
+    Modeline       "1368x768_25.00"   33.25  1368 1408 1536 1704  768 771 781 784 -hsync +vsync
+    Option         "PreferredMode" "1368x768_25.00"
 EndSection
 
 Section "Monitor"


### PR DESCRIPTION
TeamViewer/VNC resolutions should match xorg.conf Modelines to take effect.